### PR TITLE
ci: fail on lint warnings and add upstream canary workflow

### DIFF
--- a/.github/workflows/upstream-canary.yml
+++ b/.github/workflows/upstream-canary.yml
@@ -1,0 +1,91 @@
+# Canary: builds this reference implementation against upstream
+# testcontainers-ory-hydra in a matrix of upstream targets and lint modes.
+#
+# Upstream targets:
+#   - main:           unreleased upstream, substituted via a Gradle composite
+#                     build (--include-build; matched by group:name, the pinned
+#                     version is ignored). Catches breaking changes before they
+#                     are released.
+#   - latest-release: the newest published artifact from Maven Central,
+#                     selected via -PtestcontainersOryHydraVersion. Catches
+#                     drift between this app's pin and the latest release, and
+#                     exercises the artifact users actually consume.
+#
+# Lint modes:
+#   - lenient red = that upstream target actually breaks this app: act now.
+#   - strict red with lenient green = new deprecation warnings from upstream:
+#     a migration heads-up, nothing is broken yet.
+#
+# Informational only — it does not gate merges.
+name: Upstream Canary
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly, Monday 09:00 UTC.
+    - cron: '0 9 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  canary:
+    name: canary (${{ matrix.upstream }}, ${{ matrix.lint }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        upstream: [main, latest-release]
+        lint: [lenient, strict]
+    steps:
+      - uses: actions/checkout@v7
+      - name: Check out upstream testcontainers-ory-hydra (main)
+        if: matrix.upstream == 'main'
+        uses: actions/checkout@v7
+        with:
+          repository: ardetrick/testcontainers-ory-hydra
+          ref: main
+          path: upstream-library
+      - name: Resolve latest upstream release version
+        if: matrix.upstream == 'latest-release'
+        id: latest-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG=$(gh api repos/ardetrick/testcontainers-ory-hydra/releases/latest --jq .tag_name)
+          echo "Latest upstream release: $TAG"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: 'gradle'
+      - name: Setup ms-playwright cache
+        id: setup-ms-playwright-cache
+        uses: actions/cache@v6
+        with:
+          path: /home/runner/.cache/ms-playwright
+          key: ms-playwright-cache-${{ runner.os }}-${{ hashFiles('reference-app/build.gradle.kts') }}
+      - name: Install Playwright Dependencies
+        if: steps.setup-ms-playwright-cache.outputs.cache-hit != 'true'
+        run: |
+          ./gradlew playwright --args="install-deps" --no-daemon
+          ./gradlew playwright --args="install" --no-daemon
+      - name: Build against upstream main
+        if: matrix.upstream == 'main'
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+        run: >
+          ./gradlew build
+          ${{ matrix.lint == 'lenient' && '-PlenientLint=true' || '' }}
+          --include-build upstream-library --no-daemon
+      - name: Build against latest upstream release
+        if: matrix.upstream == 'latest-release'
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+        run: >
+          ./gradlew build
+          ${{ matrix.lint == 'lenient' && '-PlenientLint=true' || '' }}
+          -PtestcontainersOryHydraVersion=${{ steps.latest-release.outputs.version }}
+          --no-daemon

--- a/README.md
+++ b/README.md
@@ -333,6 +333,25 @@ Get token (no scopes screen):
 
 ![get token](docs/images/remember-me/5-after-login-submit-second-time.png)
 
+## Building against a different testcontainers-ory-hydra version
+
+The `testcontainersOryHydraVersion` Gradle property overrides the version pinned in
+`gradle/libs.versions.toml`:
+
+```
+./gradlew build -PtestcontainersOryHydraVersion=0.0.6
+```
+
+This property is relied on by the [upstream canary workflow](.github/workflows/upstream-canary.yml)
+in this repository and by the pre-release compatibility workflow in
+[testcontainers-ory-hydra](https://github.com/ardetrick/testcontainers-ory-hydra), so keep it
+intact when refactoring the build. To build against an unreleased *checkout* of the library
+instead, use a Gradle composite build:
+
+```
+./gradlew build --include-build ../testcontainers-ory-hydra
+```
+
 ## Task List
 
 - [ ] Add a fancier UI

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,7 @@
+[versions]
+# Default pin. CI overrides this via -PtestcontainersOryHydraVersion (see settings.gradle.kts);
+# do not inline this version back into build.gradle.kts.
+testcontainersOryHydra = "0.0.5"
+
+[libraries]
+testcontainers-ory-hydra = { module = "com.ardetrick.testcontainers:testcontainers-ory-hydra", version.ref = "testcontainersOryHydra" }

--- a/reference-app/build.gradle.kts
+++ b/reference-app/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     implementation("org.springframework.session:spring-session-core")
     implementation("sh.ory.hydra:hydra-client:26.2.0")
 
-    testImplementation("com.ardetrick.testcontainers:testcontainers-ory-hydra:0.0.5")
+    testImplementation(libs.testcontainers.ory.hydra)
     testImplementation("com.auth0:java-jwt:4.5.2")
     testImplementation("com.microsoft.playwright:playwright:1.61.0")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
@@ -24,6 +24,13 @@ tasks.withType<Test> {
 
 tasks.withType<JavaCompile> {
     options.compilerArgs.add("-Xlint")
+    // -Werror fails the build on any lint warning — notably uses of deprecated/for-removal
+    // upstream API. Intentional exceptions are marked with @SuppressWarnings at the call site.
+    // The upstream canary's lenient job disables it (-PlenientLint=true) so that new upstream
+    // deprecations read as a migration heads-up there, not as a break.
+    if (!providers.gradleProperty("lenientLint").map(String::toBoolean).getOrElse(false)) {
+        options.compilerArgs.add("-Werror")
+    }
 }
 
 // A way to run Playwright CLI commands using the Java source dependency.

--- a/reference-app/src/test/java/com/ardetrick/oryhydrareference/OryHydraReferenceApplicationFunctionalTests.java
+++ b/reference-app/src/test/java/com/ardetrick/oryhydrareference/OryHydraReferenceApplicationFunctionalTests.java
@@ -156,6 +156,9 @@ public class OryHydraReferenceApplicationFunctionalTests {
      * @link <a href="https://www.ory.sh/docs/reference/api#tag/wellknown/operation/discoverJsonWebKeys"/>
      */
     @Test
+    // TODO: after upgrading past testcontainers-ory-hydra 0.0.5, resolve jwks_uri from the
+    // discovery document (getOpenIdDiscoveryUri()) and drop this suppression.
+    @SuppressWarnings("removal")
     void requestToJwksUriReturns200() throws IOException, InterruptedException {
         val request = HttpRequest.newBuilder(dockerComposeEnvironment.getPublicJwksUri())
                                  .build();
@@ -195,6 +198,9 @@ public class OryHydraReferenceApplicationFunctionalTests {
         assertThat(page.content()).contains("invalid credentials try again");
     }
 
+    // TODO: after upgrading past testcontainers-ory-hydra 0.0.5, resolve authorization_endpoint
+    // from the discovery document (getOpenIdDiscoveryUri()) and drop this suppression.
+    @SuppressWarnings("removal")
     private URI getUriToInitiateFlow() {
         try {
             return new URIBuilder(dockerComposeEnvironment.getOAuth2AuthUri())

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,3 +5,19 @@ plugins {
 rootProject.name = "ory-hydra-reference"
 
 include("reference-app")
+
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            // Overwrites the catalog's testcontainersOryHydra version:
+            // ./gradlew build -PtestcontainersOryHydraVersion=<version>
+            // Relied on by .github/workflows/upstream-canary.yml in this repo AND by the
+            // reference-app-compat workflow in ardetrick/testcontainers-ory-hydra — do not
+            // remove without updating both.
+            val override = providers.gradleProperty("testcontainersOryHydraVersion")
+            if (override.isPresent) {
+                version("testcontainersOryHydra", override.get())
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds -Werror so lint warnings — notably uses of deprecated upstream API — fail compilation; the two current uses of URI helpers deprecated upstream are suppressed with TODOs to migrate to discovery-resolved URIs after the next testcontainers-ory-hydra release. -Werror can be disabled with -PlenientLint=true.

Moves the testcontainers-ory-hydra dependency into a version catalog (gradle/libs.versions.toml); a settings-level catalog overwrite lets -PtestcontainersOryHydraVersion select a different published version, which the canary uses for its latest-release jobs.

Adds a weekly/manually-dispatched canary workflow building this app against upstream in a {main, latest-release} x {lenient, strict} matrix: main via a Gradle composite build (catches unreleased breaking changes), latest-release via the newest published Maven Central artifact (catches pin drift and validates the artifact users consume). Lenient red means upstream actually breaks this app; strict red with lenient green means new deprecations to migrate. Informational only; does not gate merges.