### PR TITLE
chore: upgrade testcontainers-ory-hydra to 0.0.6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Default pin. CI overrides this via -PtestcontainersOryHydraVersion (see settings.gradle.kts);
 # do not inline this version back into build.gradle.kts.
-testcontainersOryHydra = "0.0.5"
+testcontainersOryHydra = "0.0.6"
 
 [libraries]
 testcontainers-ory-hydra = { module = "com.ardetrick.testcontainers:testcontainers-ory-hydra", version.ref = "testcontainersOryHydra" }

--- a/reference-app/src/test/java/com/ardetrick/oryhydrareference/OryHydraReferenceApplicationFunctionalTests.java
+++ b/reference-app/src/test/java/com/ardetrick/oryhydrareference/OryHydraReferenceApplicationFunctionalTests.java
@@ -156,11 +156,8 @@ public class OryHydraReferenceApplicationFunctionalTests {
      * @link <a href="https://www.ory.sh/docs/reference/api#tag/wellknown/operation/discoverJsonWebKeys"/>
      */
     @Test
-    // TODO: after upgrading past testcontainers-ory-hydra 0.0.5, resolve jwks_uri from the
-    // discovery document (getOpenIdDiscoveryUri()) and drop this suppression.
-    @SuppressWarnings("removal")
     void requestToJwksUriReturns200() throws IOException, InterruptedException {
-        val request = HttpRequest.newBuilder(dockerComposeEnvironment.getPublicJwksUri())
+        val request = HttpRequest.newBuilder(URI.create(dockerComposeEnvironment.publicBaseUriString() + "/.well-known/jwks.json"))
                                  .build();
         val response = HttpClient.newHttpClient()
                                  .send(
@@ -198,12 +195,9 @@ public class OryHydraReferenceApplicationFunctionalTests {
         assertThat(page.content()).contains("invalid credentials try again");
     }
 
-    // TODO: after upgrading past testcontainers-ory-hydra 0.0.5, resolve authorization_endpoint
-    // from the discovery document (getOpenIdDiscoveryUri()) and drop this suppression.
-    @SuppressWarnings("removal")
     private URI getUriToInitiateFlow() {
         try {
-            return new URIBuilder(dockerComposeEnvironment.getOAuth2AuthUri())
+            return new URIBuilder(dockerComposeEnvironment.publicBaseUriString() + "/oauth2/auth")
                     .addParameter("response_type", "code")
                     .addParameter("client_id", oAuth2Client.getClientId())
                     .addParameter("redirect_uri",


### PR DESCRIPTION
Bumps the pin past the release that deprecated the 0.0.5 URI helpers and migrates the two call sites off them, dropping the @SuppressWarnings placeholders — -Werror now guards the upstream deprecation boundary with no exceptions. Because this app's synthetic issuer carries a path prefix that nothing serves, the URIs are built from publicBaseUriString() rather than the discovery accessors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)