### PR TITLE
chore: complete the version catalog

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,9 +7,9 @@ repositories {
 }
 
 dependencies {
-    implementation("io.freefair.gradle:lombok-plugin:9.5.0")
-    implementation("io.spring.gradle:dependency-management-plugin:1.1.7")
-    implementation("org.gradle.toolchains:foojay-resolver:0.9.0")
+    implementation(libs.freefair.lombok.plugin)
+    implementation(libs.spring.dependency.management.plugin)
+    implementation(libs.foojay.resolver)
 }
 
 kotlin {

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,1 +1,9 @@
-rootProject.name = "buildSrc"
+// Share the root project's version catalog with buildSrc so plugin-jar versions live in
+// gradle/libs.versions.toml alongside everything else.
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,24 @@
 [versions]
+foojayResolver = "0.9.0"
+freefairLombok = "9.5.0"
+hydraClient = "26.2.0"
+javaJwt = "4.5.2"
+playwright = "1.61.0"
+springBoot = "4.1.0"
+springDependencyManagement = "1.1.7"
 # Default pin. CI overrides this via -PtestcontainersOryHydraVersion (see settings.gradle.kts);
 # do not inline this version back into build.gradle.kts.
 testcontainersOryHydra = "0.0.6"
 
 [libraries]
+auth0-java-jwt = { module = "com.auth0:java-jwt", version.ref = "javaJwt" }
+# Plugin jars consumed by buildSrc (see buildSrc/settings.gradle.kts for the catalog import).
+foojay-resolver = { module = "org.gradle.toolchains:foojay-resolver", version.ref = "foojayResolver" }
+freefair-lombok-plugin = { module = "io.freefair.gradle:lombok-plugin", version.ref = "freefairLombok" }
+microsoft-playwright = { module = "com.microsoft.playwright:playwright", version.ref = "playwright" }
+ory-hydra-client = { module = "sh.ory.hydra:hydra-client", version.ref = "hydraClient" }
+spring-dependency-management-plugin = { module = "io.spring.gradle:dependency-management-plugin", version.ref = "springDependencyManagement" }
 testcontainers-ory-hydra = { module = "com.ardetrick.testcontainers:testcontainers-ory-hydra", version.ref = "testcontainersOryHydra" }
+
+[plugins]
+spring-boot = { id = "org.springframework.boot", version.ref = "springBoot" }

--- a/reference-app/build.gradle.kts
+++ b/reference-app/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.springframework.boot") version "4.1.0"
+    alias(libs.plugins.spring.boot)
     id("project.java-conventions")
 }
 
@@ -9,11 +9,11 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.session:spring-session-core")
-    implementation("sh.ory.hydra:hydra-client:26.2.0")
+    implementation(libs.ory.hydra.client)
 
     testImplementation(libs.testcontainers.ory.hydra)
-    testImplementation("com.auth0:java-jwt:4.5.2")
-    testImplementation("com.microsoft.playwright:playwright:1.61.0")
+    testImplementation(libs.auth0.java.jwt)
+    testImplementation(libs.microsoft.playwright)
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
 }


### PR DESCRIPTION
Moves the remaining inline dependency and plugin versions into gradle/libs.versions.toml (Spring Boot plugin, hydra-client, java-jwt, playwright) and shares the catalog with buildSrc via a buildSrc/settings.gradle.kts import, so all three build layers read versions from one file. The canary's -PtestcontainersOryHydraVersion override still works through the settings-level catalog overwrite (verified by resolving a bogus version). Spring-Boot-managed starters intentionally stay as plain coordinates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)