### PR TITLE
chore: add spotless with google-java-format

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,10 +1,12 @@
 [versions]
 foojayResolver = "0.9.0"
+googleJavaFormat = "1.34.1"
 freefairLombok = "9.5.0"
 hydraClient = "26.2.0"
 javaJwt = "4.5.2"
 playwright = "1.61.0"
 springBoot = "4.1.0"
+spotless = "8.7.0"
 springDependencyManagement = "1.1.7"
 # Default pin. CI overrides this via -PtestcontainersOryHydraVersion (see settings.gradle.kts);
 # do not inline this version back into build.gradle.kts.
@@ -21,4 +23,5 @@ spring-dependency-management-plugin = { module = "io.spring.gradle:dependency-ma
 testcontainers-ory-hydra = { module = "com.ardetrick.testcontainers:testcontainers-ory-hydra", version.ref = "testcontainersOryHydra" }
 
 [plugins]
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 spring-boot = { id = "org.springframework.boot", version.ref = "springBoot" }

--- a/reference-app/build.gradle.kts
+++ b/reference-app/build.gradle.kts
@@ -1,6 +1,20 @@
 plugins {
     alias(libs.plugins.spring.boot)
+    alias(libs.plugins.spotless)
     id("project.java-conventions")
+}
+
+spotless {
+    java {
+        googleJavaFormat(libs.versions.googleJavaFormat.get())
+        formatAnnotations()
+        removeUnusedImports()
+        trimTrailingWhitespace()
+        endWithNewline()
+    }
+    kotlinGradle {
+        ktlint()
+    }
 }
 
 dependencies {

--- a/reference-app/src/main/java/com/ardetrick/oryhydrareference/OryHydraReferenceApplication.java
+++ b/reference-app/src/main/java/com/ardetrick/oryhydrareference/OryHydraReferenceApplication.java
@@ -10,18 +10,15 @@ import org.springframework.security.web.SecurityFilterChain;
 @SpringBootApplication
 public class OryHydraReferenceApplication {
 
-    public static void main(String[] args) {
-        SpringApplication.run(OryHydraReferenceApplication.class, args);
-    }
+  public static void main(String[] args) {
+    SpringApplication.run(OryHydraReferenceApplication.class, args);
+  }
 
-    @Bean
-    SecurityFilterChain securityFilterChain(HttpSecurity http) {
-        // Don't do this in production. This was removed to simplify this reference implementation.
-        http
-                .csrf(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(auth -> auth.anyRequest()
-                                                   .permitAll());
-        return http.build();
-    }
-
+  @Bean
+  SecurityFilterChain securityFilterChain(HttpSecurity http) {
+    // Don't do this in production. This was removed to simplify this reference implementation.
+    http.csrf(AbstractHttpConfigurer::disable)
+        .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+    return http.build();
+  }
 }

--- a/reference-app/src/main/java/com/ardetrick/oryhydrareference/consent/ConsentController.java
+++ b/reference-app/src/main/java/com/ardetrick/oryhydrareference/consent/ConsentController.java
@@ -15,29 +15,35 @@ import org.springframework.web.servlet.ModelAndView;
 @RequiredArgsConstructor
 public class ConsentController {
 
-    @NonNull ConsentService consentService;
+  @NonNull ConsentService consentService;
 
-    /**
-     * The Consent Endpoint (set by urls.consent) is an application written by you. You can find an exemplary Node.js reference implementation on our GitHub.
-     * The Consent Endpoint uses the consent_challenge value in the URL to fetch information about the consent request by making a HTTP GET request to:
-     * http(s)://<HYDRA_ADMIN_URL>/oauth2/auth/requests/consent?consent_challenge=<challenge>
-     * The response (see below in "Consent Challenge Response" tab) contains information about the consent request. The body contains a skip value. If the value is false, the user interface must be shown. If skip is true, you shouldn't show the user interface but instead just accept or reject the consent request! For more details about the implementation check the "Implementing the Consent Endpoint" Guide.
-     * <p>
-     * <a href="https://www.ory.sh/docs/hydra/guides/login">...</a>
-     * <a href="https://www.ory.sh/docs/hydra/concepts/consent">...</a>
-     */
-    @GetMapping
-    public ModelAndView consentEndpoint(@RequestParam("consent_challenge") final String consentChallenge) {
-        val response = consentService.processInitialConsentRequest(consentChallenge);
+  /**
+   * The Consent Endpoint (set by urls.consent) is an application written by you. You can find an
+   * exemplary Node.js reference implementation on our GitHub. The Consent Endpoint uses the
+   * consent_challenge value in the URL to fetch information about the consent request by making a
+   * HTTP GET request to:
+   * http(s)://<HYDRA_ADMIN_URL>/oauth2/auth/requests/consent?consent_challenge=<challenge> The
+   * response (see below in "Consent Challenge Response" tab) contains information about the consent
+   * request. The body contains a skip value. If the value is false, the user interface must be
+   * shown. If skip is true, you shouldn't show the user interface but instead just accept or reject
+   * the consent request! For more details about the implementation check the "Implementing the
+   * Consent Endpoint" Guide.
+   *
+   * <p><a href="https://www.ory.sh/docs/hydra/guides/login">...</a> <a
+   * href="https://www.ory.sh/docs/hydra/concepts/consent">...</a>
+   */
+  @GetMapping
+  public ModelAndView consentEndpoint(
+      @RequestParam("consent_challenge") final String consentChallenge) {
+    val response = consentService.processInitialConsentRequest(consentChallenge);
 
-        return ConsentModelAndViewMapper.map(response);
-    }
+    return ConsentModelAndViewMapper.map(response);
+  }
 
-    @PostMapping
-    public ModelAndView submitConsentForm(final ConsentForm consentForm) {
-        val consentResponse = consentService.processConsentForm(consentForm);
+  @PostMapping
+  public ModelAndView submitConsentForm(final ConsentForm consentForm) {
+    val consentResponse = consentService.processConsentForm(consentForm);
 
-        return ConsentModelAndViewMapper.map(consentResponse);
-    }
-
+    return ConsentModelAndViewMapper.map(consentResponse);
+  }
 }

--- a/reference-app/src/main/java/com/ardetrick/oryhydrareference/consent/ConsentForm.java
+++ b/reference-app/src/main/java/com/ardetrick/oryhydrareference/consent/ConsentForm.java
@@ -2,25 +2,18 @@ package com.ardetrick.oryhydrareference.consent;
 
 import java.util.List;
 
-/**
- * The Java object representing the data submitted by the form in consent.ftlh.
- */
+/** The Java object representing the data submitted by the form in consent.ftlh. */
 public record ConsentForm(
-        String submit,
-        String consentChallenge,
-        Boolean remember,
-        List<String> scopes
-) {
+    String submit, String consentChallenge, Boolean remember, List<String> scopes) {
 
-    /**
-     * This field is implemented in HTML as a checkbox. When a checkbox element is not checked in a form
-     * it is not submitted in the form at all. This provides a useful null safe getter.
-     */
-    public boolean isRemember() {
-        if (remember == null) {
-            return false;
-        }
-        return remember;
+  /**
+   * This field is implemented in HTML as a checkbox. When a checkbox element is not checked in a
+   * form it is not submitted in the form at all. This provides a useful null safe getter.
+   */
+  public boolean isRemember() {
+    if (remember == null) {
+      return false;
     }
-
+    return remember;
+  }
 }

--- a/reference-app/src/main/java/com/ardetrick/oryhydrareference/consent/ConsentModelAndViewMapper.java
+++ b/reference-app/src/main/java/com/ardetrick/oryhydrareference/consent/ConsentModelAndViewMapper.java
@@ -9,26 +9,25 @@ import org.springframework.web.servlet.ModelAndView;
 
 public class ConsentModelAndViewMapper {
 
-    public static ModelAndView map(@NonNull final ConsentResponse response) {
-        return switch (response) {
-            case Skip r -> handleSkip(r);
-            case DisplayUI r -> handleDisplayUI(r);
-            case Accepted r -> handleAccepted(r);
-        };
-    }
+  public static ModelAndView map(@NonNull final ConsentResponse response) {
+    return switch (response) {
+      case Skip r -> handleSkip(r);
+      case DisplayUI r -> handleDisplayUI(r);
+      case Accepted r -> handleAccepted(r);
+    };
+  }
 
-    private static ModelAndView handleSkip(Skip consentResponseSkip) {
-        return ModelAndViewUtils.redirectToDifferentContext(consentResponseSkip.redirectTo());
-    }
+  private static ModelAndView handleSkip(Skip consentResponseSkip) {
+    return ModelAndViewUtils.redirectToDifferentContext(consentResponseSkip.redirectTo());
+  }
 
-    private static ModelAndView handleDisplayUI(DisplayUI displayUI) {
-        return new ModelAndView("consent")
-                .addObject("consentChallenge", displayUI.consentChallenge())
-                .addObject("scopes", displayUI.requestedScopes());
-    }
+  private static ModelAndView handleDisplayUI(DisplayUI displayUI) {
+    return new ModelAndView("consent")
+        .addObject("consentChallenge", displayUI.consentChallenge())
+        .addObject("scopes", displayUI.requestedScopes());
+  }
 
-    private static ModelAndView handleAccepted(Accepted accepted) {
-        return ModelAndViewUtils.redirectToDifferentContext(accepted.redirectTo());
-    }
-
+  private static ModelAndView handleAccepted(Accepted accepted) {
+    return ModelAndViewUtils.redirectToDifferentContext(accepted.redirectTo());
+  }
 }

--- a/reference-app/src/main/java/com/ardetrick/oryhydrareference/consent/ConsentResponse.java
+++ b/reference-app/src/main/java/com/ardetrick/oryhydrareference/consent/ConsentResponse.java
@@ -2,16 +2,13 @@ package com.ardetrick.oryhydrareference.consent;
 
 import java.util.List;
 
-public sealed interface ConsentResponse permits
-        ConsentResponse.Accepted,
-        ConsentResponse.DisplayUI,
-        ConsentResponse.Skip {
+public sealed interface ConsentResponse
+    permits ConsentResponse.Accepted, ConsentResponse.DisplayUI, ConsentResponse.Skip {
 
-    record Skip(String redirectTo) implements ConsentResponse {}
+  record Skip(String redirectTo) implements ConsentResponse {}
 
-    record DisplayUI(List<String> requestedScopes,
-                     String consentChallenge) implements ConsentResponse { }
+  record DisplayUI(List<String> requestedScopes, String consentChallenge)
+      implements ConsentResponse {}
 
-    record Accepted(String redirectTo) implements ConsentResponse { }
-
+  record Accepted(String redirectTo) implements ConsentResponse {}
 }

--- a/reference-app/src/main/java/com/ardetrick/oryhydrareference/consent/ConsentService.java
+++ b/reference-app/src/main/java/com/ardetrick/oryhydrareference/consent/ConsentService.java
@@ -17,40 +17,41 @@ import org.springframework.stereotype.Service;
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class ConsentService {
 
-    @NonNull HydraAdminClient hydraAdminClient;
+  @NonNull HydraAdminClient hydraAdminClient;
 
-    public ConsentResponse processInitialConsentRequest(@NonNull final String consentChallenge) {
-        val consentRequest = hydraAdminClient.getConsentRequest(consentChallenge);
+  public ConsentResponse processInitialConsentRequest(@NonNull final String consentChallenge) {
+    val consentRequest = hydraAdminClient.getConsentRequest(consentChallenge);
 
-        if (Boolean.TRUE.equals(consentRequest.getSkip())) {
-            val acceptConsentRequest = AcceptConsentRequest.builder()
-                    .consentChallenge(consentChallenge)
-                    .remember(true)
-                    .grantAccessTokenAudience(consentRequest.getRequestedAccessTokenAudience())
-                    .scopes(consentRequest.getRequestedScope())
-                    .build();
-            val acceptConsentResponse = hydraAdminClient.acceptConsentRequest(acceptConsentRequest);
-            return new Skip(acceptConsentResponse.getRedirectTo());
-        }
-
-        return new DisplayUI(consentRequest.getRequestedScope(), consentChallenge);
+    if (Boolean.TRUE.equals(consentRequest.getSkip())) {
+      val acceptConsentRequest =
+          AcceptConsentRequest.builder()
+              .consentChallenge(consentChallenge)
+              .remember(true)
+              .grantAccessTokenAudience(consentRequest.getRequestedAccessTokenAudience())
+              .scopes(consentRequest.getRequestedScope())
+              .build();
+      val acceptConsentResponse = hydraAdminClient.acceptConsentRequest(acceptConsentRequest);
+      return new Skip(acceptConsentResponse.getRedirectTo());
     }
 
-    public ConsentResponse processConsentForm(@NonNull final ConsentForm consentForm) {
-        val consentChallenge = consentForm.consentChallenge();
+    return new DisplayUI(consentRequest.getRequestedScope(), consentChallenge);
+  }
 
-        val consentRequest = hydraAdminClient.getConsentRequest(consentChallenge);
+  public ConsentResponse processConsentForm(@NonNull final ConsentForm consentForm) {
+    val consentChallenge = consentForm.consentChallenge();
 
-        val acceptConsentRequest = AcceptConsentRequest.builder()
-                .consentChallenge(consentChallenge)
-                .remember(consentForm.isRemember())
-                .grantAccessTokenAudience(consentRequest.getRequestedAccessTokenAudience())
-                .scopes(consentForm.scopes())
-                .build();
+    val consentRequest = hydraAdminClient.getConsentRequest(consentChallenge);
 
-        val oauth2RedirectTo = hydraAdminClient.acceptConsentRequest(acceptConsentRequest);
+    val acceptConsentRequest =
+        AcceptConsentRequest.builder()
+            .consentChallenge(consentChallenge)
+            .remember(consentForm.isRemember())
+            .grantAccessTokenAudience(consentRequest.getRequestedAccessTokenAudience())
+            .scopes(consentForm.scopes())
+            .build();
 
-        return new Accepted(oauth2RedirectTo.getRedirectTo());
-    }
+    val oauth2RedirectTo = hydraAdminClient.acceptConsentRequest(acceptConsentRequest);
 
+    return new Accepted(oauth2RedirectTo.getRedirectTo());
+  }
 }

--- a/reference-app/src/main/java/com/ardetrick/oryhydrareference/demo/DemoController.java
+++ b/reference-app/src/main/java/com/ardetrick/oryhydrareference/demo/DemoController.java
@@ -15,8 +15,9 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.ModelAndView;
 
 /**
- * This controller is for demonstration purposes only to make it easier to run through the OAuth2 flow and interact with
- * Hydra clients. It is not required nor expected to be used for any production use cases.
+ * This controller is for demonstration purposes only to make it easier to run through the OAuth2
+ * flow and interact with Hydra clients. It is not required nor expected to be used for any
+ * production use cases.
  */
 @Slf4j
 @RequiredArgsConstructor
@@ -25,18 +26,19 @@ import org.springframework.web.servlet.ModelAndView;
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class DemoController {
 
-    @NonNull HydraAdminClient hydraAdminClient;
+  @NonNull HydraAdminClient hydraAdminClient;
 
-    @GetMapping(produces = {MediaType.TEXT_HTML_VALUE})
-    @ResponseBody
-    public ModelAndView test() {
-        val clients = hydraAdminClient.listOAuth2Clients()
-                .stream()
-                .map(client -> new MvcClient(client.getClientName(), client.getClientId(), client.getRedirectUris()))
-                .toList();
+  @GetMapping(produces = {MediaType.TEXT_HTML_VALUE})
+  @ResponseBody
+  public ModelAndView test() {
+    val clients =
+        hydraAdminClient.listOAuth2Clients().stream()
+            .map(
+                client ->
+                    new MvcClient(
+                        client.getClientName(), client.getClientId(), client.getRedirectUris()))
+            .toList();
 
-        return new ModelAndView("demo")
-                .addObject("clients", clients);
-    }
-
+    return new ModelAndView("demo").addObject("clients", clients);
+  }
 }

--- a/reference-app/src/main/java/com/ardetrick/oryhydrareference/hydra/AcceptConsentRequest.java
+++ b/reference-app/src/main/java/com/ardetrick/oryhydrareference/hydra/AcceptConsentRequest.java
@@ -1,13 +1,12 @@
 package com.ardetrick.oryhydrareference.hydra;
 
+import java.util.List;
 import lombok.Builder;
 import lombok.NonNull;
 
-import java.util.List;
-
 @Builder
-public record AcceptConsentRequest(@NonNull String consentChallenge,
-                            boolean remember,
-                            List<String> grantAccessTokenAudience,
-                            List<String> scopes
-) {}
+public record AcceptConsentRequest(
+    @NonNull String consentChallenge,
+    boolean remember,
+    List<String> grantAccessTokenAudience,
+    List<String> scopes) {}

--- a/reference-app/src/main/java/com/ardetrick/oryhydrareference/hydra/HydraAdminClient.java
+++ b/reference-app/src/main/java/com/ardetrick/oryhydrareference/hydra/HydraAdminClient.java
@@ -1,5 +1,7 @@
 package com.ardetrick.oryhydrareference.hydra;
 
+import java.util.List;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NonNull;
@@ -13,99 +15,90 @@ import sh.ory.hydra.Configuration;
 import sh.ory.hydra.api.OAuth2Api;
 import sh.ory.hydra.model.*;
 
-import java.util.List;
-import java.util.Optional;
-
 @Slf4j
 @Service
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class HydraAdminClient {
 
-    @NonNull OAuth2Api oAuth2Api;
+  @NonNull OAuth2Api oAuth2Api;
 
-    HydraAdminClient(@NonNull final HydraAdminClient.Properties properties) {
-        val apiClient = Configuration.getDefaultApiClient()
-                        .setBasePath(properties.getBasePath());
-        oAuth2Api = new OAuth2Api(apiClient);
+  HydraAdminClient(@NonNull final HydraAdminClient.Properties properties) {
+    val apiClient = Configuration.getDefaultApiClient().setBasePath(properties.getBasePath());
+    oAuth2Api = new OAuth2Api(apiClient);
+  }
+
+  public List<OAuth2Client> listOAuth2Clients() {
+    try {
+      return oAuth2Api.listOAuth2Clients(1000L, null, null, null);
+    } catch (ApiException e) {
+      throw new RuntimeException(e);
     }
+  }
 
-    public List<OAuth2Client> listOAuth2Clients() {
-        try {
-            return oAuth2Api.listOAuth2Clients(1000L, null, null, null);
-        } catch (ApiException e) {
-            throw new RuntimeException(e);
-        }
+  /**
+   * <a
+   * href="https://github.com/ory/hydra-client-java/blob/master/docs/OAuth2Api.md#getoauth2loginrequest">...</a>
+   */
+  public Optional<OAuth2LoginRequest> getLoginRequest(@NonNull String loginChallenge) {
+    try {
+      return Optional.of(oAuth2Api.getOAuth2LoginRequest(loginChallenge));
+    } catch (ApiException e) {
+      return switch (e.getCode()) {
+        case 410 -> Optional.empty(); // requestWasHandledResponse
+        case 400, 404 -> Optional.empty(); // jsonError
+        case 500 -> Optional.empty(); // jsonError
+        default -> throw new RuntimeException("unhandled code: " + e.getCode(), e);
+      };
     }
+  }
 
-    /**
-     * <a href="https://github.com/ory/hydra-client-java/blob/master/docs/OAuth2Api.md#getoauth2loginrequest">...</a>
-     */
-    public Optional<OAuth2LoginRequest> getLoginRequest(@NonNull String loginChallenge) {
-        try {
-            return Optional.of(oAuth2Api.getOAuth2LoginRequest(loginChallenge));
-        } catch (ApiException e) {
-            return switch (e.getCode()) {
-                case 410 -> Optional.empty(); // requestWasHandledResponse
-                case 400, 404 -> Optional.empty(); // jsonError
-                case 500 -> Optional.empty(); // jsonError
-                default -> throw new RuntimeException("unhandled code: " + e.getCode(), e);
-            };
-        }
+  public OAuth2RedirectTo acceptLoginRequest(
+      @NonNull String loginChallenge, @NonNull String loginEmail) {
+    val acceptLoginRequest = new AcceptOAuth2LoginRequest();
+    // Subject is an alias for user ID. A subject can be a random string, a UUID, an email address,
+    // ...
+    acceptLoginRequest.subject(loginEmail);
+    try {
+      return oAuth2Api.acceptOAuth2LoginRequest(loginChallenge, acceptLoginRequest);
+    } catch (ApiException e) {
+      switch (e.getCode()) {
+        case 400, 401, 404, 500 ->
+            throw new RuntimeException("code: " + e.getCode(), e); // jsonError
+        default -> throw new RuntimeException("unhandled code: " + e.getCode(), e);
+      }
     }
+  }
 
-    public OAuth2RedirectTo acceptLoginRequest(
-            @NonNull String loginChallenge,
-            @NonNull String loginEmail
-    ) {
-        val acceptLoginRequest = new AcceptOAuth2LoginRequest();
-        // Subject is an alias for user ID. A subject can be a random string, a UUID, an email address, ...
-        acceptLoginRequest.subject(loginEmail);
-        try {
-            return oAuth2Api.acceptOAuth2LoginRequest(loginChallenge, acceptLoginRequest);
-        } catch (ApiException e) {
-            switch (e.getCode()) {
-                case 400, 401, 404, 500 -> throw new RuntimeException("code: " + e.getCode(), e); // jsonError
-                default -> throw new RuntimeException("unhandled code: " + e.getCode(), e);
-            }
-        }
+  public OAuth2ConsentRequest getConsentRequest(@NonNull String consentChallenge) {
+    try {
+      return oAuth2Api.getOAuth2ConsentRequest(consentChallenge);
+    } catch (ApiException e) {
+      switch (e.getCode()) {
+        case 400, 404 -> throw new RuntimeException("code: " + e.getCode(), e); // jsonError
+        default -> throw new RuntimeException("unhandled code: " + e.getCode(), e);
+      }
     }
+  }
 
-    public OAuth2ConsentRequest getConsentRequest(@NonNull String consentChallenge) {
-        try {
-            return oAuth2Api.getOAuth2ConsentRequest(consentChallenge);
-        } catch (ApiException e) {
-            switch (e.getCode()) {
-                case 400, 404 -> throw new RuntimeException("code: " + e.getCode(), e); // jsonError
-                default -> throw new RuntimeException("unhandled code: " + e.getCode(), e);
-            }
-        }
+  public OAuth2RedirectTo acceptConsentRequest(@NonNull AcceptConsentRequest acceptConsentRequest) {
+    val acceptOAuth2ConsentRequest = OryHydraRequestMapper.map(acceptConsentRequest);
+
+    try {
+      return oAuth2Api.acceptOAuth2ConsentRequest(
+          acceptConsentRequest.consentChallenge(), acceptOAuth2ConsentRequest);
+    } catch (ApiException e) {
+      switch (e.getCode()) {
+        case 404, 500 -> throw new RuntimeException("code: " + e.getCode(), e); // jsonError
+        default -> throw new RuntimeException("unhandled code: " + e.getCode(), e);
+      }
     }
+  }
 
-    public OAuth2RedirectTo acceptConsentRequest(
-            @NonNull AcceptConsentRequest acceptConsentRequest
-    ) {
-        val acceptOAuth2ConsentRequest = OryHydraRequestMapper.map(acceptConsentRequest);
+  @Data
+  @org.springframework.context.annotation.Configuration
+  @ConfigurationProperties("reference-app.hydra")
+  public static class Properties {
 
-        try {
-            return oAuth2Api.acceptOAuth2ConsentRequest(
-                    acceptConsentRequest.consentChallenge(),
-                    acceptOAuth2ConsentRequest
-            );
-        } catch (ApiException e) {
-            switch (e.getCode()) {
-                case 404, 500 -> throw new RuntimeException("code: " + e.getCode(), e); // jsonError
-                default -> throw new RuntimeException("unhandled code: " + e.getCode(), e);
-            }
-        }
-    }
-
-    @Data
-    @org.springframework.context.annotation.Configuration
-    @ConfigurationProperties("reference-app.hydra")
-    public static class Properties {
-
-        String basePath = "http://localhost:4445";
-
-    }
-
+    String basePath = "http://localhost:4445";
+  }
 }

--- a/reference-app/src/main/java/com/ardetrick/oryhydrareference/hydra/OryHydraRequestMapper.java
+++ b/reference-app/src/main/java/com/ardetrick/oryhydrareference/hydra/OryHydraRequestMapper.java
@@ -6,23 +6,23 @@ import sh.ory.hydra.model.AcceptOAuth2ConsentRequestSession;
 
 public class OryHydraRequestMapper {
 
-    private static final Long DEFAULT_SESSION_EXPIRATION_IN_SECONDS = 3600L;
+  private static final Long DEFAULT_SESSION_EXPIRATION_IN_SECONDS = 3600L;
 
-    public static AcceptOAuth2ConsentRequest map(@NonNull final AcceptConsentRequest acceptConsentRequest) {
-        return new AcceptOAuth2ConsentRequest()
-                .grantScope(acceptConsentRequest.scopes())
-                .grantAccessTokenAudience(acceptConsentRequest.grantAccessTokenAudience())
-                .remember(acceptConsentRequest.remember())
-                .rememberFor(DEFAULT_SESSION_EXPIRATION_IN_SECONDS)
-                .session(getAcceptOAuth2ConsentRequestSession());
-    }
+  public static AcceptOAuth2ConsentRequest map(
+      @NonNull final AcceptConsentRequest acceptConsentRequest) {
+    return new AcceptOAuth2ConsentRequest()
+        .grantScope(acceptConsentRequest.scopes())
+        .grantAccessTokenAudience(acceptConsentRequest.grantAccessTokenAudience())
+        .remember(acceptConsentRequest.remember())
+        .rememberFor(DEFAULT_SESSION_EXPIRATION_IN_SECONDS)
+        .session(getAcceptOAuth2ConsentRequestSession());
+  }
 
-    private static AcceptOAuth2ConsentRequestSession getAcceptOAuth2ConsentRequestSession() {
-        // An example of setting custom claims.
-        record ExampleCustomClaims(String exampleCustomClaimKey) {}
+  private static AcceptOAuth2ConsentRequestSession getAcceptOAuth2ConsentRequestSession() {
+    // An example of setting custom claims.
+    record ExampleCustomClaims(String exampleCustomClaimKey) {}
 
-        return new AcceptOAuth2ConsentRequestSession()
-                .idToken(new ExampleCustomClaims("example custom claim value"));
-    }
-
+    return new AcceptOAuth2ConsentRequestSession()
+        .idToken(new ExampleCustomClaims("example custom claim value"));
+  }
 }

--- a/reference-app/src/main/java/com/ardetrick/oryhydrareference/login/LoginController.java
+++ b/reference-app/src/main/java/com/ardetrick/oryhydrareference/login/LoginController.java
@@ -20,41 +20,37 @@ import org.springframework.web.servlet.ModelAndView;
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class LoginController {
 
-    @NonNull LoginService loginService;
+  @NonNull LoginService loginService;
 
-    /**
-     * This is the endpoint which Ory Hydra redirects to after a resource owner initiates the OAuth flow. It is
-     * responsible for verifying the login challenge. Based on the current authentication state returned from Hydra
-     * the OAuth flow may be continued (the "optimistic" login case) or they will be redirected to a UI, so they can
-     * explicitly authenticate themselves.
-     */
-    @GetMapping
-    public ModelAndView loginOptimistically(@RequestParam("login_challenge") String loginChallenge) {
-        val loginResult = loginService.processInitialLoginRequest(loginChallenge);
+  /**
+   * This is the endpoint which Ory Hydra redirects to after a resource owner initiates the OAuth
+   * flow. It is responsible for verifying the login challenge. Based on the current authentication
+   * state returned from Hydra the OAuth flow may be continued (the "optimistic" login case) or they
+   * will be redirected to a UI, so they can explicitly authenticate themselves.
+   */
+  @GetMapping
+  public ModelAndView loginOptimistically(@RequestParam("login_challenge") String loginChallenge) {
+    val loginResult = loginService.processInitialLoginRequest(loginChallenge);
 
-        return LoginModelAndViewMapper.toView(loginResult, loginChallenge);
-    }
+    return LoginModelAndViewMapper.toView(loginResult, loginChallenge);
+  }
 
-    /**
-     * An implementation of the Ory Hydra Login Endpoint. This endpoint is responsible for fulfilling the
-     * responsibilities of the login endpoint as outlined by the Ory Hydra documentation.
-     * </p>
-     * One of the requirements of this endpoint is to authenticate the user. As per the OAuth specification
-     * the identity of the resource owner must be verified, but the way in which that authentication is done is not
-     * specified.
-     * </p>
-     * For the purposes of this demo a credentials are used but other approaches such as session cookies could be used.
-     *
-     * @see <a href="https://www.rfc-editor.org/rfc/rfc6749#section-3.1">RFC 6749 Section 3.1</a>
-     * @see <a href="https://www.ory.sh/docs/hydra/guides/login">Implementing The Login Endpoint</a>
-     */
-    @PostMapping("usernamePassword")
-    public ModelAndView loginWithUsernamePasswordForm(
-            LoginForm loginForm
-    ) {
-        val loginResult = loginService.processSubmittedLoginRequest(loginForm.loginChallenge(), loginForm);
+  /**
+   * An implementation of the Ory Hydra Login Endpoint. This endpoint is responsible for fulfilling
+   * the responsibilities of the login endpoint as outlined by the Ory Hydra documentation. One of
+   * the requirements of this endpoint is to authenticate the user. As per the OAuth specification
+   * the identity of the resource owner must be verified, but the way in which that authentication
+   * is done is not specified. For the purposes of this demo a credentials are used but other
+   * approaches such as session cookies could be used.
+   *
+   * @see <a href="https://www.rfc-editor.org/rfc/rfc6749#section-3.1">RFC 6749 Section 3.1</a>
+   * @see <a href="https://www.ory.sh/docs/hydra/guides/login">Implementing The Login Endpoint</a>
+   */
+  @PostMapping("usernamePassword")
+  public ModelAndView loginWithUsernamePasswordForm(LoginForm loginForm) {
+    val loginResult =
+        loginService.processSubmittedLoginRequest(loginForm.loginChallenge(), loginForm);
 
-        return LoginModelAndViewMapper.toView(loginResult, loginForm.loginChallenge());
-    }
-
+    return LoginModelAndViewMapper.toView(loginResult, loginForm.loginChallenge());
+  }
 }

--- a/reference-app/src/main/java/com/ardetrick/oryhydrareference/login/LoginForm.java
+++ b/reference-app/src/main/java/com/ardetrick/oryhydrareference/login/LoginForm.java
@@ -1,5 +1,3 @@
 package com.ardetrick.oryhydrareference.login;
 
-public record LoginForm(String loginEmail,
-                        String loginPassword,
-                        String loginChallenge) {}
+public record LoginForm(String loginEmail, String loginPassword, String loginChallenge) {}

--- a/reference-app/src/main/java/com/ardetrick/oryhydrareference/login/LoginModelAndViewMapper.java
+++ b/reference-app/src/main/java/com/ardetrick/oryhydrareference/login/LoginModelAndViewMapper.java
@@ -12,28 +12,27 @@ import org.springframework.web.servlet.ModelAndView;
 @UtilityClass
 public class LoginModelAndViewMapper {
 
-    public static ModelAndView toView(@NonNull final LoginResult loginResult,
-                                      @NonNull final String loginChallenge) {
-        return switch (loginResult) {
-            case LoginAcceptedFollowRedirect(String redirectUrl) ->
-                    ModelAndViewUtils.redirectToDifferentContext(redirectUrl);
-            case LoginResult.LoginDeniedInvalidCredentials ignored -> {
-                val loginModelAndView = new ModelAndView();
-                loginModelAndView.setViewName("/login");
-                loginModelAndView.addObject("loginChallenge", loginChallenge);
-                loginModelAndView.addObject("error", "invalid credentials try again");
+  public static ModelAndView toView(
+      @NonNull final LoginResult loginResult, @NonNull final String loginChallenge) {
+    return switch (loginResult) {
+      case LoginAcceptedFollowRedirect(String redirectUrl) ->
+          ModelAndViewUtils.redirectToDifferentContext(redirectUrl);
+      case LoginResult.LoginDeniedInvalidCredentials ignored -> {
+        val loginModelAndView = new ModelAndView();
+        loginModelAndView.setViewName("/login");
+        loginModelAndView.addObject("loginChallenge", loginChallenge);
+        loginModelAndView.addObject("error", "invalid credentials try again");
 
-                yield loginModelAndView;
-            }
-            case LoginNotSkippableDisplayLoginUI ignored -> {
-                val loginModelAndView = new ModelAndView();
-                loginModelAndView.setViewName("/login");
-                loginModelAndView.addObject("loginChallenge", loginChallenge);
+        yield loginModelAndView;
+      }
+      case LoginNotSkippableDisplayLoginUI ignored -> {
+        val loginModelAndView = new ModelAndView();
+        loginModelAndView.setViewName("/login");
+        loginModelAndView.addObject("loginChallenge", loginChallenge);
 
-                yield loginModelAndView;
-            }
-            case LoginRequestNotFound ignored -> new ModelAndView("/home");
-        };
-    }
-
+        yield loginModelAndView;
+      }
+      case LoginRequestNotFound ignored -> new ModelAndView("/home");
+    };
+  }
 }

--- a/reference-app/src/main/java/com/ardetrick/oryhydrareference/login/LoginResult.java
+++ b/reference-app/src/main/java/com/ardetrick/oryhydrareference/login/LoginResult.java
@@ -1,18 +1,16 @@
 package com.ardetrick.oryhydrareference.login;
 
-public sealed interface LoginResult permits
-        LoginResult.LoginNotSkippableDisplayLoginUI,
+public sealed interface LoginResult
+    permits LoginResult.LoginNotSkippableDisplayLoginUI,
         LoginResult.LoginAcceptedFollowRedirect,
         LoginResult.LoginDeniedInvalidCredentials,
         LoginResult.LoginRequestNotFound {
 
-    record LoginAcceptedFollowRedirect(String redirectUrl) implements LoginResult {}
+  record LoginAcceptedFollowRedirect(String redirectUrl) implements LoginResult {}
 
-    record LoginDeniedInvalidCredentials() implements LoginResult {}
+  record LoginDeniedInvalidCredentials() implements LoginResult {}
 
-    record LoginRequestNotFound() implements LoginResult {}
+  record LoginRequestNotFound() implements LoginResult {}
 
-    record LoginNotSkippableDisplayLoginUI(String loginChallenge) implements LoginResult {}
-
-
+  record LoginNotSkippableDisplayLoginUI(String loginChallenge) implements LoginResult {}
 }

--- a/reference-app/src/main/java/com/ardetrick/oryhydrareference/login/LoginService.java
+++ b/reference-app/src/main/java/com/ardetrick/oryhydrareference/login/LoginService.java
@@ -5,6 +5,7 @@ import com.ardetrick.oryhydrareference.login.LoginResult.LoginAcceptedFollowRedi
 import com.ardetrick.oryhydrareference.login.LoginResult.LoginDeniedInvalidCredentials;
 import com.ardetrick.oryhydrareference.login.LoginResult.LoginNotSkippableDisplayLoginUI;
 import com.ardetrick.oryhydrareference.login.LoginResult.LoginRequestNotFound;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -13,59 +14,59 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.springframework.stereotype.Component;
 
-import java.util.Optional;
-
 @Slf4j
 @Component
 @RequiredArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class LoginService {
 
-    @NonNull
-    HydraAdminClient hydraAdminClient;
+  @NonNull HydraAdminClient hydraAdminClient;
 
-    public LoginResult processInitialLoginRequest(@NonNull String loginChallenge) {
-        val maybeLoginRequest = hydraAdminClient.getLoginRequest(loginChallenge);
-        if (maybeLoginRequest.isEmpty()) {
-            return new LoginRequestNotFound();
-        }
-
-        val loginRequest = maybeLoginRequest.get();
-
-        if (loginRequest.getSkip()) {
-            hydraAdminClient.acceptLoginRequest(loginChallenge, loginRequest.getSubject());
-            return new LoginAcceptedFollowRedirect(loginRequest.getRequestUrl());
-        }
-
-        return new LoginNotSkippableDisplayLoginUI(loginChallenge);
+  public LoginResult processInitialLoginRequest(@NonNull String loginChallenge) {
+    val maybeLoginRequest = hydraAdminClient.getLoginRequest(loginChallenge);
+    if (maybeLoginRequest.isEmpty()) {
+      return new LoginRequestNotFound();
     }
 
-    public LoginResult processSubmittedLoginRequest(@NonNull String loginChallenge, LoginForm loginForm) {
-        val maybeLoginRequest = hydraAdminClient.getLoginRequest(loginChallenge);
-        if (maybeLoginRequest.isEmpty()) {
-            return new LoginRequestNotFound();
-        }
+    val loginRequest = maybeLoginRequest.get();
 
-        val maybeInvalidCredentialsResult = checkForInvalidCredentialsResult(loginForm);
-        if (maybeInvalidCredentialsResult.isPresent()) {
-            return maybeInvalidCredentialsResult.get();
-        }
-
-        val completedRequest = hydraAdminClient.acceptLoginRequest(loginChallenge, loginForm.loginEmail());
-
-        return new LoginAcceptedFollowRedirect(completedRequest.getRedirectTo());
+    if (loginRequest.getSkip()) {
+      hydraAdminClient.acceptLoginRequest(loginChallenge, loginRequest.getSubject());
+      return new LoginAcceptedFollowRedirect(loginRequest.getRequestUrl());
     }
 
-    private static Optional<LoginDeniedInvalidCredentials> checkForInvalidCredentialsResult(LoginForm loginForm) {
-        // Naive authentication logic. In reality this should delegate to a real authentication system.
-        if (loginForm.loginEmail() == null || loginForm.loginPassword() == null) {
-            return Optional.of(new LoginDeniedInvalidCredentials());
-        }
-        if (!"foo@bar.com".equals(loginForm.loginEmail()) || !"password".equals(loginForm.loginPassword())) {
-            return Optional.of(new LoginDeniedInvalidCredentials());
-        }
+    return new LoginNotSkippableDisplayLoginUI(loginChallenge);
+  }
 
-        return Optional.empty();
+  public LoginResult processSubmittedLoginRequest(
+      @NonNull String loginChallenge, LoginForm loginForm) {
+    val maybeLoginRequest = hydraAdminClient.getLoginRequest(loginChallenge);
+    if (maybeLoginRequest.isEmpty()) {
+      return new LoginRequestNotFound();
     }
 
+    val maybeInvalidCredentialsResult = checkForInvalidCredentialsResult(loginForm);
+    if (maybeInvalidCredentialsResult.isPresent()) {
+      return maybeInvalidCredentialsResult.get();
+    }
+
+    val completedRequest =
+        hydraAdminClient.acceptLoginRequest(loginChallenge, loginForm.loginEmail());
+
+    return new LoginAcceptedFollowRedirect(completedRequest.getRedirectTo());
+  }
+
+  private static Optional<LoginDeniedInvalidCredentials> checkForInvalidCredentialsResult(
+      LoginForm loginForm) {
+    // Naive authentication logic. In reality this should delegate to a real authentication system.
+    if (loginForm.loginEmail() == null || loginForm.loginPassword() == null) {
+      return Optional.of(new LoginDeniedInvalidCredentials());
+    }
+    if (!"foo@bar.com".equals(loginForm.loginEmail())
+        || !"password".equals(loginForm.loginPassword())) {
+      return Optional.of(new LoginDeniedInvalidCredentials());
+    }
+
+    return Optional.empty();
+  }
 }

--- a/reference-app/src/main/java/com/ardetrick/oryhydrareference/login/package-info.java
+++ b/reference-app/src/main/java/com/ardetrick/oryhydrareference/login/package-info.java
@@ -1,6 +1,3 @@
 package com.ardetrick.oryhydrareference.login;
 
-/**
- * https://www.ory.sh/docs/hydra/concepts/login
- * https://www.ory.sh/docs/hydra/guides/login
- */
+/** https://www.ory.sh/docs/hydra/concepts/login https://www.ory.sh/docs/hydra/guides/login */

--- a/reference-app/src/main/java/com/ardetrick/oryhydrareference/modelandview/ModelAndViewUtils.java
+++ b/reference-app/src/main/java/com/ardetrick/oryhydrareference/modelandview/ModelAndViewUtils.java
@@ -8,8 +8,7 @@ import org.springframework.web.servlet.view.RedirectView;
 @UtilityClass
 public class ModelAndViewUtils {
 
-    public ModelAndView redirectToDifferentContext(@NonNull String redirectUrl) {
-        return new ModelAndView(new RedirectView(redirectUrl, false));
-    }
-
+  public ModelAndView redirectToDifferentContext(@NonNull String redirectUrl) {
+    return new ModelAndView(new RedirectView(redirectUrl, false));
+  }
 }

--- a/reference-app/src/test/java/com/ardetrick/oryhydrareference/OryHydraReferenceApplicationFunctionalTests.java
+++ b/reference-app/src/test/java/com/ardetrick/oryhydrareference/OryHydraReferenceApplicationFunctionalTests.java
@@ -1,5 +1,9 @@
 package com.ardetrick.oryhydrareference;
 
+import static com.ardetrick.oryhydrareference.ClientCallBackController.CLIENT_CALL_BACK_PATH;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.verify;
+
 import com.ardetrick.oryhydrareference.hydra.HydraAdminClient;
 import com.ardetrick.oryhydrareference.test.utils.ScreenshotPathProducer;
 import com.ardetrick.testcontainers.OryHydraContainer;
@@ -13,6 +17,17 @@ import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.net.URIBuilder;
 import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.Playwright;
 import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.junit.jupiter.api.*;
@@ -35,514 +50,468 @@ import sh.ory.hydra.Configuration;
 import sh.ory.hydra.api.OAuth2Api;
 import sh.ory.hydra.model.OAuth2Client;
 
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URLEncoder;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.nio.charset.StandardCharsets;
-import java.util.*;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-
-import static com.ardetrick.oryhydrareference.ClientCallBackController.CLIENT_CALL_BACK_PATH;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.Mockito.verify;
-
 @Slf4j
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Import({
-        ClientCallBackController.class,
-        ForwardingController.class,
+  ClientCallBackController.class,
+  ForwardingController.class,
 })
 @TestPropertySource(properties = {"debug=true"})
 public class OryHydraReferenceApplicationFunctionalTests {
 
-    // Shared between all tests in this class.
-    private static Playwright playwright;
-    private static Browser browser;
+  // Shared between all tests in this class.
+  private static Playwright playwright;
+  private static Browser browser;
 
-    @LocalServerPort
-    int springBootAppPort;
+  @LocalServerPort int springBootAppPort;
 
-    OryHydraContainer dockerComposeEnvironment;
+  OryHydraContainer dockerComposeEnvironment;
 
-    OAuth2Client oAuth2Client;
+  OAuth2Client oAuth2Client;
 
-    @Autowired
-    HydraAdminClient.Properties properties;
+  @Autowired HydraAdminClient.Properties properties;
 
-    @MockitoBean
-    Consumer<String> queryStringConsumer;
-    @Captor
-    ArgumentCaptor<String> queryStringConsumerArgumentCaptor = ArgumentCaptor.forClass(String.class);
+  @MockitoBean Consumer<String> queryStringConsumer;
 
-    @BeforeAll
-    static void beforeAll() {
-        playwright = Playwright.create();
-        browser = playwright.chromium()
-                            .launch();
+  @Captor
+  ArgumentCaptor<String> queryStringConsumerArgumentCaptor = ArgumentCaptor.forClass(String.class);
+
+  @BeforeAll
+  static void beforeAll() {
+    playwright = Playwright.create();
+    browser = playwright.chromium().launch();
+  }
+
+  @AfterAll
+  static void afterAll() {
+    playwright.close();
+  }
+
+  @BeforeEach
+  public void beforeEachTest() throws ApiException {
+    // Start Ory Hydra, passing it the port of the reference application to configure urls.
+    // An alternative approach would be to start the container once and re-use it across all tests.
+    // However, @BeforeAllTests requires the method be static but @LocalServerPort is unavailable
+    // statically.
+    // Creating the containers for each test increases test execution time but keeps all tests
+    // isolated.
+    dockerComposeEnvironment =
+        OryHydraContainer.builder()
+            .urlsLogin("http://localhost:" + springBootAppPort + "/login")
+            .urlsConsent("http://localhost:" + springBootAppPort + "/consent")
+            .urlsSelfIssuer(
+                "http://localhost:" + springBootAppPort + "/integration-test-public-proxy")
+            .build();
+    dockerComposeEnvironment.start();
+
+    // A "cheat" to break a circular dependency where the reference application needs to know the
+    // URI of Ory Hydra
+    // and Ory Hydra needs to know the URI of the reference application. In a production application
+    // these two URIs
+    // should be static and well known. However, in the context of these tests the ports of both the
+    // reference
+    // application and Ory Hydra are randomized and are unknown until after the application is
+    // already running
+    // (this follows testing best practices where hard coding ports should be avoided in case the
+    // host machine is
+    // already using that port). There may be a cleaner approach out there (perhaps using Docker
+    // Networking?) but
+    // in the meantime this is a low cost and sufficient work around.
+    properties.setBasePath(dockerComposeEnvironment.publicBaseUriString());
+
+    oAuth2Client = createOAuthClient();
+  }
+
+  @AfterEach
+  public void afterEachTest() {
+    // Test containers must be stopped to avoid a port conflict error when starting them up again
+    // for the next test.
+    dockerComposeEnvironment.stop();
+  }
+
+  private OAuth2Client createOAuthClient() throws ApiException {
+    val oAuth2Client = new OAuth2Client();
+    oAuth2Client.clientName("test-client");
+    oAuth2Client.redirectUris(
+        List.of("http://localhost:" + springBootAppPort + CLIENT_CALL_BACK_PATH));
+    oAuth2Client.grantTypes(List.of("authorization_code", "refresh_token"));
+    oAuth2Client.responseTypes(List.of("code", "id_token"));
+    oAuth2Client.clientSecret("client-secret");
+    oAuth2Client.scope(String.join(" ", "offline_access", "openid", "offline", "profile"));
+
+    // Initialize API
+    val oauth2Api =
+        new OAuth2Api(
+            Configuration.getDefaultApiClient()
+                .setBasePath(dockerComposeEnvironment.adminBaseUriString()));
+
+    // Create client
+    val oauth2Client = oauth2Api.createOAuth2Client(oAuth2Client);
+
+    // Basic assertions on created client
+    assertThat(oauth2Api.getOAuth2Client(oauth2Client.getClientId())).isNotNull();
+
+    return oauth2Client;
+  }
+
+  /**
+   * Tests that the .well-known/jwks.json URI is exposed and accessible.
+   *
+   * @link <a
+   *     href="https://www.ory.sh/docs/reference/api#tag/wellknown/operation/discoverJsonWebKeys"/>
+   */
+  @Test
+  void requestToJwksUriReturns200() throws IOException, InterruptedException {
+    val request =
+        HttpRequest.newBuilder(
+                URI.create(
+                    dockerComposeEnvironment.publicBaseUriString() + "/.well-known/jwks.json"))
+            .build();
+    val response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+
+    assertThat(response.statusCode()).isEqualTo(200);
+  }
+
+  @Test
+  public void loginInvalidCredentials() {
+    val screenshotPathProducer =
+        ScreenshotPathProducer.builder().testName("loginInvalidCredentials").build();
+
+    val page = browser.newPage();
+    val initiateFlowUri = getUriToInitiateFlow();
+
+    page.navigate(initiateFlowUri.toString());
+    page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("initial-load"));
+
+    page.locator("input[name=loginEmail]").fill("foo@bar.com");
+    page.locator("input[name=loginPassword]").fill("password1");
+
+    page.locator("input[name=submit]").click();
+
+    page.waitForLoadState();
+    page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("after-login-submit"));
+
+    assertThat(page.content()).contains("invalid credentials try again");
+  }
+
+  private URI getUriToInitiateFlow() {
+    try {
+      return new URIBuilder(dockerComposeEnvironment.publicBaseUriString() + "/oauth2/auth")
+          .addParameter("response_type", "code")
+          .addParameter("client_id", oAuth2Client.getClientId())
+          .addParameter(
+              "redirect_uri", Objects.requireNonNull(oAuth2Client.getRedirectUris()).get(0))
+          .addParameter("scope", "offline_access openid offline profile")
+          .addParameter("state", "12345678901234567890")
+          .build();
+    } catch (URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  public void completeFullOAuthFlowUsingUIToLogin() {
+    val screenshotPathProducer =
+        ScreenshotPathProducer.builder().testName("completeFullOAuthFlowUsingUIToLogin").build();
+
+    val page = browser.newPage();
+
+    val uri = getUriToInitiateFlow();
+
+    page.navigate(uri.toString());
+    page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("initial-load"));
+
+    page.locator("input[name=loginEmail]").fill("foo@bar.com");
+    page.locator("input[name=loginPassword]").fill("password");
+
+    page.locator("input[name=submit]").click();
+
+    page.waitForLoadState();
+
+    page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("after-login-submit"));
+
+    page.locator("input[id=accept]").click();
+
+    page.waitForLoadState();
+
+    page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("after-consent-submit"));
+
+    val code = getCodeFromCallbackCaptor();
+    val token = exchangeCode(code);
+
+    assertThat(token.accessToken()).isNotBlank();
+    assertThat(token.refreshToken()).isNotBlank();
+    assertThat(token.idToken()).isNotBlank();
+
+    val decodedJWT = JWT.decode(token.idToken());
+    assertThat(decodedJWT.getClaim("exampleCustomClaimKey").asString())
+        .isNotNull()
+        .isEqualTo("example custom claim value");
+  }
+
+  @Test
+  public void completeFlowWithPartialScopeSelection() {
+    val screenshotPathProducer =
+        ScreenshotPathProducer.builder().testName("completeFlowWithPartialScopeSelection").build();
+
+    val page = browser.newPage();
+
+    val uri = getUriToInitiateFlow();
+
+    page.navigate(uri.toString());
+    page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("initial-load"));
+
+    page.locator("input[name=loginEmail]").fill("foo@bar.com");
+    page.locator("input[name=loginPassword]").fill("password");
+
+    page.locator("input[name=submit]").click();
+
+    page.waitForLoadState();
+
+    page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("after-login-submit"));
+
+    page.locator("input[id=scopes-profile]").uncheck();
+
+    page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("after-uncheck-scope"));
+
+    page.locator("input[id=accept]").click();
+
+    page.waitForLoadState();
+
+    page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("after-consent-submit"));
+
+    val code = getCodeFromCallbackCaptor();
+    val token = exchangeCode(code);
+
+    assertThat(token.accessToken()).isNotBlank();
+    assertThat(token.refreshToken()).isNotBlank();
+    assertThat(token.idToken()).isNotBlank();
+    assertThat(token.scope()).doesNotContain("profile");
+  }
+
+  private CodeExchangeResponse exchangeCode(String code) {
+    val encodedParams =
+        Map.of(
+                "client_id",
+                Objects.requireNonNull(oAuth2Client.getClientId()),
+                "code",
+                code,
+                "grant_type",
+                Objects.requireNonNull(Objects.requireNonNull(oAuth2Client.getGrantTypes()).get(0)),
+                "redirect_uri",
+                Objects.requireNonNull(oAuth2Client.getRedirectUris()).get(0))
+            .entrySet()
+            .stream()
+            .map(
+                entry ->
+                    String.join(
+                        "=",
+                        URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8),
+                        URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8)))
+            .collect(Collectors.joining("&"));
+
+    val request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(dockerComposeEnvironment.publicBaseUriString() + "/oauth2/token"))
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .header(
+                "authorization",
+                "Basic "
+                    + Base64.getEncoder()
+                        .encodeToString(
+                            (oAuth2Client.getClientId() + ":" + oAuth2Client.getClientSecret())
+                                .getBytes()))
+            .POST(HttpRequest.BodyPublishers.ofString(encodedParams))
+            .build();
+
+    HttpResponse<String> codeExchangeResponse;
+    try {
+      codeExchangeResponse =
+          HttpClient.newBuilder().build().send(request, HttpResponse.BodyHandlers.ofString());
+    } catch (IOException | InterruptedException e) {
+      throw new RuntimeException(e);
     }
 
-    @AfterAll
-    static void afterAll() {
-        playwright.close();
+    assertThat(codeExchangeResponse.statusCode()).isEqualTo(200);
+
+    try {
+      return new ObjectMapper().readValue(codeExchangeResponse.body(), CodeExchangeResponse.class);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
     }
+  }
 
-    @BeforeEach
-    public void beforeEachTest() throws ApiException {
-        // Start Ory Hydra, passing it the port of the reference application to configure urls.
-        // An alternative approach would be to start the container once and re-use it across all tests.
-        // However, @BeforeAllTests requires the method be static but @LocalServerPort is unavailable statically.
-        // Creating the containers for each test increases test execution time but keeps all tests isolated.
-        dockerComposeEnvironment = OryHydraContainer.builder()
-                                                     .urlsLogin("http://localhost:" + springBootAppPort + "/login")
-                                                     .urlsConsent("http://localhost:" + springBootAppPort + "/consent")
-                                                     .urlsSelfIssuer("http://localhost:" + springBootAppPort + "/integration-test-public-proxy")
-                                                     .build();
-        dockerComposeEnvironment.start();
-
-        // A "cheat" to break a circular dependency where the reference application needs to know the URI of Ory Hydra
-        // and Ory Hydra needs to know the URI of the reference application. In a production application these two URIs
-        // should be static and well known. However, in the context of these tests the ports of both the reference
-        // application and Ory Hydra are randomized and are unknown until after the application is already running
-        // (this follows testing best practices where hard coding ports should be avoided in case the host machine is
-        // already using that port). There may be a cleaner approach out there (perhaps using Docker Networking?) but
-        // in the meantime this is a low cost and sufficient work around.
-        properties.setBasePath(dockerComposeEnvironment.publicBaseUriString());
-
-        oAuth2Client = createOAuthClient();
-    }
-
-    @AfterEach
-    public void afterEachTest() {
-        // Test containers must be stopped to avoid a port conflict error when starting them up again for the next test.
-        dockerComposeEnvironment.stop();
-    }
-
-    private OAuth2Client createOAuthClient() throws ApiException {
-        val oAuth2Client = new OAuth2Client();
-        oAuth2Client.clientName("test-client");
-        oAuth2Client.redirectUris(List.of("http://localhost:" + springBootAppPort + CLIENT_CALL_BACK_PATH));
-        oAuth2Client.grantTypes(List.of(
-                "authorization_code",
-                "refresh_token"
-        ));
-        oAuth2Client.responseTypes(List.of("code", "id_token"));
-        oAuth2Client.clientSecret("client-secret");
-        oAuth2Client.scope(String.join(" ", "offline_access", "openid", "offline", "profile"));
-
-        // Initialize API
-        val oauth2Api = new OAuth2Api(
-                Configuration.getDefaultApiClient()
-                             .setBasePath(dockerComposeEnvironment.adminBaseUriString())
-        );
-
-        // Create client
-        val oauth2Client = oauth2Api.createOAuth2Client(oAuth2Client);
-
-        // Basic assertions on created client
-        assertThat(oauth2Api.getOAuth2Client(oauth2Client.getClientId()))
-                .isNotNull();
-
-        return oauth2Client;
-    }
-
-    /**
-     * Tests that the .well-known/jwks.json URI is exposed and accessible.
-     *
-     * @link <a href="https://www.ory.sh/docs/reference/api#tag/wellknown/operation/discoverJsonWebKeys"/>
-     */
-    @Test
-    void requestToJwksUriReturns200() throws IOException, InterruptedException {
-        val request = HttpRequest.newBuilder(URI.create(dockerComposeEnvironment.publicBaseUriString() + "/.well-known/jwks.json"))
-                                 .build();
-        val response = HttpClient.newHttpClient()
-                                 .send(
-                                         request,
-                                         HttpResponse.BodyHandlers.ofString()
-                                 );
-
-        assertThat(response.statusCode())
-                .isEqualTo(200);
-    }
-
-    @Test
-    public void loginInvalidCredentials() {
-        val screenshotPathProducer = ScreenshotPathProducer.builder()
-                                                           .testName("loginInvalidCredentials")
-                                                           .build();
-
-        val page = browser.newPage();
-        val initiateFlowUri = getUriToInitiateFlow();
-
-        page.navigate(initiateFlowUri.toString());
-        page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("initial-load"));
-
-        page.locator("input[name=loginEmail]")
-            .fill("foo@bar.com");
-        page.locator("input[name=loginPassword]")
-            .fill("password1");
-
-        page.locator("input[name=submit]")
-            .click();
-
-        page.waitForLoadState();
-        page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("after-login-submit"));
+  @Test
+  public void skipConsentScreenOnSecondLoginWhenRememberMeIsUsed() {
+    val screenshotPathProducer =
+        ScreenshotPathProducer.builder()
+            .testName("skipConsentScreenOnSecondLoginWhenRememberMeIsUsed")
+            .build();
+    val page = browser.newPage();
 
-        assertThat(page.content()).contains("invalid credentials try again");
-    }
+    val uri = getUriToInitiateFlow();
 
-    private URI getUriToInitiateFlow() {
-        try {
-            return new URIBuilder(dockerComposeEnvironment.publicBaseUriString() + "/oauth2/auth")
-                    .addParameter("response_type", "code")
-                    .addParameter("client_id", oAuth2Client.getClientId())
-                    .addParameter("redirect_uri",
-                                  Objects.requireNonNull(oAuth2Client.getRedirectUris())
-                                         .get(0))
-                    .addParameter("scope", "offline_access openid offline profile")
-                    .addParameter("state", "12345678901234567890")
-                    .build();
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
-    }
+    page.navigate(uri.toString());
+    page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("initial-load"));
 
-    @Test
-    public void completeFullOAuthFlowUsingUIToLogin() {
-        val screenshotPathProducer = ScreenshotPathProducer.builder()
-                                                           .testName("completeFullOAuthFlowUsingUIToLogin")
-                                                           .build();
+    page.locator("input[name=loginEmail]").fill("foo@bar.com");
+    page.locator("input[name=loginPassword]").fill("password");
 
-        val page = browser.newPage();
+    page.locator("input[name=submit]").click();
 
-        val uri = getUriToInitiateFlow();
-
-        page.navigate(uri.toString());
-        page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("initial-load"));
-
-        page.locator("input[name=loginEmail]")
-            .fill("foo@bar.com");
-        page.locator("input[name=loginPassword]")
-            .fill("password");
-
-        page.locator("input[name=submit]")
-            .click();
-
-        page.waitForLoadState();
-
-        page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("after-login-submit"));
-
-        page.locator("input[id=accept]")
-            .click();
-
-        page.waitForLoadState();
-
-        page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("after-consent-submit"));
-
-        val code = getCodeFromCallbackCaptor();
-        val token = exchangeCode(code);
-
-        assertThat(token.accessToken())
-                .isNotBlank();
-        assertThat(token.refreshToken())
-                .isNotBlank();
-        assertThat(token.idToken())
-                .isNotBlank();
-
-        val decodedJWT = JWT.decode(token.idToken());
-        assertThat(decodedJWT.getClaim("exampleCustomClaimKey")
-                             .asString())
-                .isNotNull()
-                .isEqualTo("example custom claim value");
-    }
-
-    @Test
-    public void completeFlowWithPartialScopeSelection() {
-        val screenshotPathProducer = ScreenshotPathProducer.builder()
-                                                           .testName("completeFlowWithPartialScopeSelection")
-                                                           .build();
-
-        val page = browser.newPage();
-
-        val uri = getUriToInitiateFlow();
-
-        page.navigate(uri.toString());
-        page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("initial-load"));
-
-        page.locator("input[name=loginEmail]")
-            .fill("foo@bar.com");
-        page.locator("input[name=loginPassword]")
-            .fill("password");
-
-        page.locator("input[name=submit]")
-            .click();
-
-        page.waitForLoadState();
-
-        page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("after-login-submit"));
-
-        page.locator("input[id=scopes-profile]")
-            .uncheck();
-
-        page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("after-uncheck-scope"));
-
-        page.locator("input[id=accept]")
-            .click();
-
-        page.waitForLoadState();
-
-        page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("after-consent-submit"));
-
-        val code = getCodeFromCallbackCaptor();
-        val token = exchangeCode(code);
-
-        assertThat(token.accessToken())
-                .isNotBlank();
-        assertThat(token.refreshToken())
-                .isNotBlank();
-        assertThat(token.idToken())
-                .isNotBlank();
-        assertThat(token.scope()).doesNotContain("profile");
-    }
-
-    private CodeExchangeResponse exchangeCode(String code) {
-        val encodedParams = Map.of(
-                                       "client_id",
-                                       Objects.requireNonNull(oAuth2Client.getClientId()),
-                                       "code",
-                                       code,
-                                       "grant_type",
-                                       Objects.requireNonNull(Objects.requireNonNull(oAuth2Client.getGrantTypes())
-                                                                     .get(0)),
-                                       "redirect_uri",
-                                       Objects.requireNonNull(oAuth2Client.getRedirectUris())
-                                              .get(0)
-                               )
-                               .entrySet()
-                               .stream()
-                               .map(entry -> String.join("=",
-                                                         URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8),
-                                                         URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8))
-                               )
-                               .collect(Collectors.joining("&"));
-
-        val request = HttpRequest.newBuilder()
-                                 .uri(URI.create(dockerComposeEnvironment.publicBaseUriString() + "/oauth2/token"))
-                                 .header("Content-Type", "application/x-www-form-urlencoded")
-                                 .header("authorization",
-                                         "Basic " + Base64.getEncoder()
-                                                          .encodeToString((oAuth2Client.getClientId() + ":" + oAuth2Client.getClientSecret()).getBytes()))
-                                 .POST(HttpRequest.BodyPublishers.ofString(encodedParams))
-                                 .build();
-
-        HttpResponse<String> codeExchangeResponse;
-        try {
-            codeExchangeResponse = HttpClient.newBuilder()
-                                             .build()
-                                             .send(request, HttpResponse.BodyHandlers.ofString());
-        } catch (IOException | InterruptedException e) {
-            throw new RuntimeException(e);
-        }
-
-        assertThat(codeExchangeResponse.statusCode()).isEqualTo(200);
-
-        try {
-            return new ObjectMapper().readValue(codeExchangeResponse.body(), CodeExchangeResponse.class);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    @Test
-    public void skipConsentScreenOnSecondLoginWhenRememberMeIsUsed() {
-        val screenshotPathProducer = ScreenshotPathProducer.builder()
-                                                           .testName("skipConsentScreenOnSecondLoginWhenRememberMeIsUsed")
-                                                           .build();
-        val page = browser.newPage();
+    page.waitForLoadState();
 
-        val uri = getUriToInitiateFlow();
+    page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("after-login-submit"));
 
-        page.navigate(uri.toString());
-        page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("initial-load"));
+    page.locator("input[id=accept]").click();
 
-        page.locator("input[name=loginEmail]")
-            .fill("foo@bar.com");
-        page.locator("input[name=loginPassword]")
-            .fill("password");
+    page.waitForLoadState();
 
-        page.locator("input[name=submit]")
-            .click();
+    page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("after-consent-submit"));
 
-        page.waitForLoadState();
+    val code = getCodeFromCallbackCaptor();
+    exchangeCode(code);
 
-        page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("after-login-submit"));
+    page.navigate(getUriToInitiateFlow().toString());
+    page.screenshot(
+        screenshotPathProducer.screenshotOptionsForStepName("initial-load-second-time"));
 
-        page.locator("input[id=accept]")
-            .click();
+    page.locator("input[name=loginEmail]").fill("foo@bar.com");
+    page.locator("input[name=loginPassword]").fill("password");
 
-        page.waitForLoadState();
+    page.locator("input[name=submit]").click();
 
-        page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("after-consent-submit"));
+    page.waitForLoadState();
 
-        val code = getCodeFromCallbackCaptor();
-        exchangeCode(code);
+    page.screenshot(
+        screenshotPathProducer.screenshotOptionsForStepName("after-login-submit-second-time"));
 
-        page.navigate(getUriToInitiateFlow().toString());
-        page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("initial-load-second-time"));
+    // Consent screen is skipped
+    assertThat(page.url()).contains("/client/callback?code=");
+  }
 
-        page.locator("input[name=loginEmail]")
-            .fill("foo@bar.com");
-        page.locator("input[name=loginPassword]")
-            .fill("password");
+  private String getCodeFromCallbackCaptor() {
+    verify(queryStringConsumer).accept(queryStringConsumerArgumentCaptor.capture());
+    val queryStringValue = queryStringConsumerArgumentCaptor.getValue();
+    return Arrays.stream(queryStringValue.split("&"))
+        .filter(queryStringParam -> queryStringParam.startsWith("code="))
+        .findFirst()
+        .map(queryStringParam -> queryStringParam.replace("code=", ""))
+        .orElseThrow();
+  }
 
-        page.locator("input[name=submit]")
-            .click();
+  @Test
+  public void doNotSkipConsentScreenOnSecondLoginWhenRememberMeIsFalse() {
+    val screenshotPathProducer =
+        ScreenshotPathProducer.builder()
+            .testName("doNotSkipConsentScreenOnSecondLoginWhenRememberMeIsFalse")
+            .build();
 
-        page.waitForLoadState();
+    val page = browser.newPage();
 
-        page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("after-login-submit-second-time"));
+    val uri = getUriToInitiateFlow();
 
-        // Consent screen is skipped
-        assertThat(page.url()).contains("/client/callback?code=");
-    }
+    page.navigate(uri.toString());
+    page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("initial-load"));
 
-    private String getCodeFromCallbackCaptor() {
-        verify(queryStringConsumer)
-                .accept(queryStringConsumerArgumentCaptor.capture());
-        val queryStringValue = queryStringConsumerArgumentCaptor.getValue();
-        return Arrays.stream(queryStringValue.split("&"))
-                     .filter(queryStringParam -> queryStringParam.startsWith("code="))
-                     .findFirst()
-                     .map(queryStringParam -> queryStringParam.replace("code=", ""))
-                     .orElseThrow();
-    }
+    page.locator("input[name=loginEmail]").fill("foo@bar.com");
+    page.locator("input[name=loginPassword]").fill("password");
 
-    @Test
-    public void doNotSkipConsentScreenOnSecondLoginWhenRememberMeIsFalse() {
-        val screenshotPathProducer = ScreenshotPathProducer.builder()
-                                                           .testName("doNotSkipConsentScreenOnSecondLoginWhenRememberMeIsFalse")
-                                                           .build();
+    page.locator("input[name=submit]").click();
 
-        val page = browser.newPage();
+    page.waitForLoadState();
+    page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("after-login-submit"));
 
-        val uri = getUriToInitiateFlow();
+    page.locator("input[id=remember]").uncheck();
 
-        page.navigate(uri.toString());
-        page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("initial-load"));
+    page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("after-uncheck"));
 
-        page.locator("input[name=loginEmail]")
-            .fill("foo@bar.com");
-        page.locator("input[name=loginPassword]")
-            .fill("password");
+    page.locator("input[id=accept]").click();
 
-        page.locator("input[name=submit]")
-            .click();
+    page.waitForLoadState();
 
-        page.waitForLoadState();
-        page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("after-login-submit"));
+    page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("after-consent-submit"));
 
-        page.locator("input[id=remember]")
-            .uncheck();
+    val code = getCodeFromCallbackCaptor();
+    exchangeCode(code);
 
-        page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("after-uncheck"));
+    page.navigate(getUriToInitiateFlow().toString());
+    page.screenshot(
+        screenshotPathProducer.screenshotOptionsForStepName("initial-load-second-time"));
 
-        page.locator("input[id=accept]")
-            .click();
+    page.locator("input[name=loginEmail]").fill("foo@bar.com");
+    page.locator("input[name=loginPassword]").fill("password");
 
-        page.waitForLoadState();
+    page.locator("input[name=submit]").click();
 
-        page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("after-consent-submit"));
+    page.waitForLoadState();
 
-        val code = getCodeFromCallbackCaptor();
-        exchangeCode(code);
+    page.screenshot(
+        screenshotPathProducer.screenshotOptionsForStepName("after-login-submit-second-time"));
 
-        page.navigate(getUriToInitiateFlow().toString());
-        page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("initial-load-second-time"));
-
-        page.locator("input[name=loginEmail]")
-            .fill("foo@bar.com");
-        page.locator("input[name=loginPassword]")
-            .fill("password");
-
-        page.locator("input[name=submit]")
-            .click();
-
-        page.waitForLoadState();
-
-        page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("after-login-submit-second-time"));
-
-        // Consent screen is not skipped
-        assertThat(page.url()).contains("/consent");
-    }
-
+    // Consent screen is not skipped
+    assertThat(page.url()).contains("/consent");
+  }
 }
 
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 record CodeExchangeResponse(
-        @JsonProperty("access_token") String accessToken,
-        @JsonProperty("expires_in") long expiresIn,
-        @JsonProperty("id_token") String idToken,
-        @JsonProperty("refresh_token") String refreshToken,
-        @JsonProperty("scope") String scope,
-        @JsonProperty("token_type") String tokenType
-) {
-}
+    @JsonProperty("access_token") String accessToken,
+    @JsonProperty("expires_in") long expiresIn,
+    @JsonProperty("id_token") String idToken,
+    @JsonProperty("refresh_token") String refreshToken,
+    @JsonProperty("scope") String scope,
+    @JsonProperty("token_type") String tokenType) {}
 
 /**
- * A controller that exposes an endpoint which acts as a proxy to the oauth server. This proxy is used to break the
- * unfortunate circular dependency between Hydra and the reference app. They each need to know about each other at
- * startup, but within the context of testing both are using random ports, so it is impossible for each to know
- * about each other until after the ports have been assigned. By using this proxy the cycle is broken. The reference
+ * A controller that exposes an endpoint which acts as a proxy to the oauth server. This proxy is
+ * used to break the unfortunate circular dependency between Hydra and the reference app. They each
+ * need to know about each other at startup, but within the context of testing both are using random
+ * ports, so it is impossible for each to know about each other until after the ports have been
+ * assigned. By using this proxy the cycle is broken. The reference
  */
 @TestComponent
 @Controller
 @RequestMapping("/integration-test-public-proxy")
 class ForwardingController {
 
-    @Autowired
-    HydraAdminClient.Properties properties;
+  @Autowired HydraAdminClient.Properties properties;
 
-    @GetMapping("oauth2/auth")
-    public RedirectView oauth2Auth() {
-        val redirectView = new RedirectView(properties.getBasePath() + "/oauth2/auth");
-        redirectView.setPropagateQueryParams(true);
-        return redirectView;
-    }
+  @GetMapping("oauth2/auth")
+  public RedirectView oauth2Auth() {
+    val redirectView = new RedirectView(properties.getBasePath() + "/oauth2/auth");
+    redirectView.setPropagateQueryParams(true);
+    return redirectView;
+  }
 
-    @GetMapping("oauth2/fallbacks/error")
-    public String oauth2FallbacksError(HttpServletRequest request) {
-        return null;
-    }
-
+  @GetMapping("oauth2/fallbacks/error")
+  public String oauth2FallbacksError(HttpServletRequest request) {
+    return null;
+  }
 }
 
 /**
- * A controller that mocks a client call back. Upon receiving a request it invokes a consumer, providing a hook for
- * tests to 1) assert that the callback was made and 2) use an argument captor to access the query string. This makes it
- * possible for a test to then parse the query string to get the "code" parameter and exchange it with the auth server
- * for the token response.
- * <p>
- * An alternative approach would be to start an entirely separate app but that seemed like more hassle than is worth it.
+ * A controller that mocks a client call back. Upon receiving a request it invokes a consumer,
+ * providing a hook for tests to 1) assert that the callback was made and 2) use an argument captor
+ * to access the query string. This makes it possible for a test to then parse the query string to
+ * get the "code" parameter and exchange it with the auth server for the token response.
+ *
+ * <p>An alternative approach would be to start an entirely separate app but that seemed like more
+ * hassle than is worth it.
  */
 @TestComponent
 @RestController
 @RequestMapping(CLIENT_CALL_BACK_PATH)
 class ClientCallBackController {
 
-    public static final String CLIENT_CALL_BACK_PATH = "/client/callback";
+  public static final String CLIENT_CALL_BACK_PATH = "/client/callback";
 
-    @Autowired
-    Consumer<String> queryStringConsumer;
+  @Autowired Consumer<String> queryStringConsumer;
 
-    @GetMapping
-    public String oauth2Auth(HttpServletRequest request) {
-        queryStringConsumer.accept(request.getQueryString());
+  @GetMapping
+  public String oauth2Auth(HttpServletRequest request) {
+    queryStringConsumer.accept(request.getQueryString());
 
-        return "call back received: " + request.getQueryString();
-    }
-
+    return "call back received: " + request.getQueryString();
+  }
 }

--- a/reference-app/src/test/java/com/ardetrick/oryhydrareference/OryHydraReferenceApplicationTest.java
+++ b/reference-app/src/test/java/com/ardetrick/oryhydrareference/OryHydraReferenceApplicationTest.java
@@ -6,7 +6,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class OryHydraReferenceApplicationTest {
 
-    @Test
-    public void contextStarts() {}
-
+  @Test
+  public void contextStarts() {}
 }

--- a/reference-app/src/test/java/com/ardetrick/oryhydrareference/hydra/HydraAdminClientTest.java
+++ b/reference-app/src/test/java/com/ardetrick/oryhydrareference/hydra/HydraAdminClientTest.java
@@ -2,8 +2,4 @@ package com.ardetrick.oryhydrareference.hydra;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class HydraAdminClientTest {
-
-
-
-}
+class HydraAdminClientTest {}

--- a/reference-app/src/test/java/com/ardetrick/oryhydrareference/login/LoginControllerTest.java
+++ b/reference-app/src/test/java/com/ardetrick/oryhydrareference/login/LoginControllerTest.java
@@ -1,5 +1,10 @@
 package com.ardetrick.oryhydrareference.login;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
 import com.ardetrick.oryhydrareference.login.LoginResult.LoginAcceptedFollowRedirect;
 import com.ardetrick.oryhydrareference.login.LoginResult.LoginNotSkippableDisplayLoginUI;
 import lombok.val;
@@ -10,63 +15,63 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.hamcrest.Matchers.containsString;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
-
 @WebMvcTest(LoginController.class)
 class LoginControllerTest {
 
-    @Autowired
-    MockMvc mockMvc;
+  @Autowired MockMvc mockMvc;
 
-    @MockitoBean
-    LoginService loginService;
+  @MockitoBean LoginService loginService;
 
-    @MockitoBean
-    SecurityFilterChain securityFilterChain;
+  @MockitoBean SecurityFilterChain securityFilterChain;
 
-    @Test
-    public void loginOptimistically_whenMissingLoginChallengeQueryParam_shouldReturn400() throws Exception {
-        val loginChallenge = "example-login-challenge";
+  @Test
+  public void loginOptimistically_whenMissingLoginChallengeQueryParam_shouldReturn400()
+      throws Exception {
+    val loginChallenge = "example-login-challenge";
 
-        when(loginService.processInitialLoginRequest(loginChallenge))
-                .thenReturn(new LoginAcceptedFollowRedirect("redirect-location"));
+    when(loginService.processInitialLoginRequest(loginChallenge))
+        .thenReturn(new LoginAcceptedFollowRedirect("redirect-location"));
 
-        mockMvc.perform(get("/login"))
-               .andExpect(status().isBadRequest());
-    }
+    mockMvc.perform(get("/login")).andExpect(status().isBadRequest());
+  }
 
-    @Test
-    public void loginOptimistically_shouldHandleRedirectResponse() throws Exception {
-        val loginChallenge = "example-login-challenge";
+  @Test
+  public void loginOptimistically_shouldHandleRedirectResponse() throws Exception {
+    val loginChallenge = "example-login-challenge";
 
-        when(loginService.processInitialLoginRequest(loginChallenge))
-                .thenReturn(new LoginAcceptedFollowRedirect("redirect-location"));
+    when(loginService.processInitialLoginRequest(loginChallenge))
+        .thenReturn(new LoginAcceptedFollowRedirect("redirect-location"));
 
-        mockMvc.perform(get("/login").queryParam("login_challenge", loginChallenge))
-               .andExpect(status().isFound())
-               .andExpect(header().exists("location"))
-               .andExpect(header().stringValues("location", "redirect-location"));
-    }
+    mockMvc
+        .perform(get("/login").queryParam("login_challenge", loginChallenge))
+        .andExpect(status().isFound())
+        .andExpect(header().exists("location"))
+        .andExpect(header().stringValues("location", "redirect-location"));
+  }
 
-    @Test
-    public void loginOptimistically_loginDisplay() throws Exception {
-        val loginChallenge = "example-login-challenge";
+  @Test
+  public void loginOptimistically_loginDisplay() throws Exception {
+    val loginChallenge = "example-login-challenge";
 
-        when(loginService.processInitialLoginRequest(loginChallenge))
-                .thenReturn(new LoginNotSkippableDisplayLoginUI(loginChallenge));
+    when(loginService.processInitialLoginRequest(loginChallenge))
+        .thenReturn(new LoginNotSkippableDisplayLoginUI(loginChallenge));
 
-        mockMvc.perform(get("/login").queryParam("login_challenge", loginChallenge))
-               .andExpect(status().isOk())
-               .andExpect(content().string(containsString("""
+    mockMvc
+        .perform(get("/login").queryParam("login_challenge", loginChallenge))
+        .andExpect(status().isOk())
+        .andExpect(
+            content()
+                .string(
+                    containsString(
+                        """
                                                                   <form action="/login/usernamePassword" method="post">
                                                                   """)))
-               .andExpect(content().string(containsString("""
+        .andExpect(
+            content()
+                .string(
+                    containsString(
+                        """
                                                                   <input type="hidden" name="loginChallenge" value="example-login-challenge" />
-                                                                  """
-               )));
-    }
-
+                                                                  """)));
+  }
 }

--- a/reference-app/src/test/java/com/ardetrick/oryhydrareference/test/utils/ScreenshotPathProducer.java
+++ b/reference-app/src/test/java/com/ardetrick/oryhydrareference/test/utils/ScreenshotPathProducer.java
@@ -1,32 +1,29 @@
 package com.ardetrick.oryhydrareference.test.utils;
 
 import com.microsoft.playwright.Page;
+import java.nio.file.Paths;
 import lombok.Builder;
 import lombok.NonNull;
 import lombok.Value;
 import lombok.experimental.NonFinal;
 import lombok.val;
 
-import java.nio.file.Paths;
-
 @Value
 @Builder
 public class ScreenshotPathProducer {
 
-    private static final String PREFIX = "build/test-results/screenshots/";
+  private static final String PREFIX = "build/test-results/screenshots/";
 
-    @NonNull String testName;
-    @NonFinal @Builder.Default int currentIndexPrefix = 1;
+  @NonNull String testName;
+  @NonFinal @Builder.Default int currentIndexPrefix = 1;
 
-    public Page.ScreenshotOptions screenshotOptionsForStepName(String stepName) {
-        return new Page.ScreenshotOptions()
-                .setPath(Paths.get(getPathAndIncrementIndex(stepName)));
-    }
+  public Page.ScreenshotOptions screenshotOptionsForStepName(String stepName) {
+    return new Page.ScreenshotOptions().setPath(Paths.get(getPathAndIncrementIndex(stepName)));
+  }
 
-    private String getPathAndIncrementIndex(String stepName) {
-        val path = PREFIX + testName + "/" + currentIndexPrefix + "-" + stepName + ".png";
-        currentIndexPrefix++;
-        return path;
-    }
-
+  private String getPathAndIncrementIndex(String stepName) {
+    val path = PREFIX + testName + "/" + currentIndexPrefix + "-" + stepName + ".png";
+    currentIndexPrefix++;
+    return path;
+  }
 }


### PR DESCRIPTION
Adopts the same formatting setup as testcontainers-ory-hydra: spotless with google-java-format (plus formatAnnotations, removeUnusedImports, whitespace hygiene) for Java and ktlint for the Gradle Kotlin scripts, wired into the existing CI build via spotlessCheck. Includes the one-time whole-codebase reformat (24 files) — blame noise on this single commit in exchange for enforced consistency after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)