### PR TITLE
ci: install chromium only and key the browser cache on the catalog

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,12 +34,11 @@ jobs:
           # Some dependencies are downloaded to this directory
           path: /home/runner/.cache/ms-playwright
           # There probably is a smarter way to create this key but this should be ok for now.
-          key: ms-playwright-cache-${{ runner.os }}-${{ hashFiles('**/build.gradle.kts') }}
+          key: ms-playwright-chromium-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
       - name: Install Playwright Dependencies
         if: steps.setup-ms-playwright-cache.outputs.cache-hit != 'true'
-        run: |
-          ./gradlew playwright --args="install-deps" --no-daemon
-          ./gradlew playwright --args="install" --no-daemon
+        # Chromium only — the only browser the tests use; one Gradle invocation.
+        run: ./gradlew playwright --args="install --with-deps chromium" --no-daemon
       - name: build
         env:
           # Browsers will have been installed earlier

--- a/.github/workflows/upstream-canary.yml
+++ b/.github/workflows/upstream-canary.yml
@@ -69,9 +69,8 @@ jobs:
           key: ms-playwright-cache-${{ runner.os }}-${{ hashFiles('reference-app/build.gradle.kts') }}
       - name: Install Playwright Dependencies
         if: steps.setup-ms-playwright-cache.outputs.cache-hit != 'true'
-        run: |
-          ./gradlew playwright --args="install-deps" --no-daemon
-          ./gradlew playwright --args="install" --no-daemon
+        # Chromium only — the only browser the tests use; one Gradle invocation.
+        run: ./gradlew playwright --args="install --with-deps chromium" --no-daemon
       - name: Build against upstream main
         if: matrix.upstream == 'main'
         env:


### PR DESCRIPTION
The tests launch chromium exclusively, so installing all three browser families wasted download time and cache size; a single install --with-deps chromium invocation replaces the two Gradle runs. Also fixes a latent cache bug from the version-catalog migration: the key hashed build.gradle.kts, which no longer contains the Playwright version, so a Playwright bump would have restored stale browsers that PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD then refused to replace. The key now hashes gradle/libs.versions.toml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)