### PR TITLE
ci: adopt gradle/actions/setup-gradle

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,7 +26,8 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-          cache: 'gradle'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
       - name: Setup ms-playwright cache
         id: setup-ms-playwright-cache
         uses: actions/cache@v6

--- a/.github/workflows/upstream-canary.yml
+++ b/.github/workflows/upstream-canary.yml
@@ -60,7 +60,8 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-          cache: 'gradle'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
       - name: Setup ms-playwright cache
         id: setup-ms-playwright-cache
         uses: actions/cache@v6


### PR DESCRIPTION
Replaces setup-java's coarse gradle cache with the Gradle-recommended setup-gradle action in CI and the upstream canary: finer-grained caching with automatic cleanup and read-only caches on non-default branches, Gradle wrapper checksum validation, and build/cache job summaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)