### PR TITLE
ci: key the browser cache on the Playwright version alone

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -28,14 +28,18 @@ jobs:
           distribution: 'temurin'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
+      # Key the browser cache on the Playwright version alone so unrelated dependency
+      # bumps in the catalog do not trigger a browser reinstall.
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: echo "version=$(grep -m1 '^playwright = ' gradle/libs.versions.toml | cut -d'"' -f2)" >> "$GITHUB_OUTPUT"
       - name: Setup ms-playwright cache
         id: setup-ms-playwright-cache
         uses: actions/cache@v6
         with:
           # Some dependencies are downloaded to this directory
           path: /home/runner/.cache/ms-playwright
-          # There probably is a smarter way to create this key but this should be ok for now.
-          key: ms-playwright-chromium-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
+          key: ms-playwright-chromium-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
       - name: Install Playwright Dependencies
         if: steps.setup-ms-playwright-cache.outputs.cache-hit != 'true'
         # Chromium only — the only browser the tests use; one Gradle invocation.

--- a/.github/workflows/upstream-canary.yml
+++ b/.github/workflows/upstream-canary.yml
@@ -62,12 +62,17 @@ jobs:
           distribution: 'temurin'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
+      # Key the browser cache on the Playwright version alone so unrelated dependency
+      # bumps do not trigger a browser reinstall.
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: echo "version=$(grep -m1 '^playwright = ' gradle/libs.versions.toml | cut -d'"' -f2)" >> "$GITHUB_OUTPUT"
       - name: Setup ms-playwright cache
         id: setup-ms-playwright-cache
         uses: actions/cache@v6
         with:
           path: /home/runner/.cache/ms-playwright
-          key: ms-playwright-cache-${{ runner.os }}-${{ hashFiles('reference-app/build.gradle.kts') }}
+          key: ms-playwright-chromium-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
       - name: Install Playwright Dependencies
         if: steps.setup-ms-playwright-cache.outputs.cache-hit != 'true'
         # Chromium only — the only browser the tests use; one Gradle invocation.


### PR DESCRIPTION
Hashing the whole catalog meant any dependency bump paid the 60s cold browser install; the key now uses the Playwright version itself. Also fixes the canary, which had silently kept the original build.gradle.kts-based key when the chromium-only change landed — it still carried the stale-cache bug (a Playwright bump would restore old browsers that PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD refuses to replace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)