### PR TITLE
feat: reject the consent request when the user denies access

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ instead, use a Gradle composite build:
 - [ ] Add a fancier UI
 - [ ] Refactor controller/service logic to be more consistent
 - [ ] Tests to mock Ory Hydra responses
-- [ ] Allow rejecting on consent screen
+- [x] Allow rejecting on consent screen
 - [ ] Add more unit tests
 - [ ] Document playwright usage
 - [ ] Show login errors on login screen

--- a/reference-app/src/main/java/com/ardetrick/oryhydrareference/consent/ConsentForm.java
+++ b/reference-app/src/main/java/com/ardetrick/oryhydrareference/consent/ConsentForm.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 /** The Java object representing the data submitted by the form in consent.ftlh. */
 public record ConsentForm(
-    String submit, String consentChallenge, Boolean remember, List<String> scopes) {
+    String consentChallenge, Boolean remember, List<String> scopes, String deny) {
 
   /**
    * This field is implemented in HTML as a checkbox. When a checkbox element is not checked in a
@@ -15,5 +15,13 @@ public record ConsentForm(
       return false;
     }
     return remember;
+  }
+
+  /**
+   * The form has two submit buttons and only the one actually clicked is included in the form post,
+   * so this field is non-null exactly when the user clicked "Deny access".
+   */
+  public boolean isDenied() {
+    return deny != null;
   }
 }

--- a/reference-app/src/main/java/com/ardetrick/oryhydrareference/consent/ConsentModelAndViewMapper.java
+++ b/reference-app/src/main/java/com/ardetrick/oryhydrareference/consent/ConsentModelAndViewMapper.java
@@ -1,6 +1,7 @@
 package com.ardetrick.oryhydrareference.consent;
 
 import com.ardetrick.oryhydrareference.consent.ConsentResponse.Accepted;
+import com.ardetrick.oryhydrareference.consent.ConsentResponse.Denied;
 import com.ardetrick.oryhydrareference.consent.ConsentResponse.DisplayUI;
 import com.ardetrick.oryhydrareference.consent.ConsentResponse.Skip;
 import com.ardetrick.oryhydrareference.modelandview.ModelAndViewUtils;
@@ -14,6 +15,7 @@ public class ConsentModelAndViewMapper {
       case Skip r -> handleSkip(r);
       case DisplayUI r -> handleDisplayUI(r);
       case Accepted r -> handleAccepted(r);
+      case Denied r -> handleDenied(r);
     };
   }
 
@@ -29,5 +31,10 @@ public class ConsentModelAndViewMapper {
 
   private static ModelAndView handleAccepted(Accepted accepted) {
     return ModelAndViewUtils.redirectToDifferentContext(accepted.redirectTo());
+  }
+
+  // Hydra's redirect carries the OAuth error (error=access_denied&...) back to the client.
+  private static ModelAndView handleDenied(Denied denied) {
+    return ModelAndViewUtils.redirectToDifferentContext(denied.redirectTo());
   }
 }

--- a/reference-app/src/main/java/com/ardetrick/oryhydrareference/consent/ConsentResponse.java
+++ b/reference-app/src/main/java/com/ardetrick/oryhydrareference/consent/ConsentResponse.java
@@ -3,7 +3,10 @@ package com.ardetrick.oryhydrareference.consent;
 import java.util.List;
 
 public sealed interface ConsentResponse
-    permits ConsentResponse.Accepted, ConsentResponse.DisplayUI, ConsentResponse.Skip {
+    permits ConsentResponse.Accepted,
+        ConsentResponse.Denied,
+        ConsentResponse.DisplayUI,
+        ConsentResponse.Skip {
 
   record Skip(String redirectTo) implements ConsentResponse {}
 
@@ -11,4 +14,6 @@ public sealed interface ConsentResponse
       implements ConsentResponse {}
 
   record Accepted(String redirectTo) implements ConsentResponse {}
+
+  record Denied(String redirectTo) implements ConsentResponse {}
 }

--- a/reference-app/src/main/java/com/ardetrick/oryhydrareference/consent/ConsentService.java
+++ b/reference-app/src/main/java/com/ardetrick/oryhydrareference/consent/ConsentService.java
@@ -1,10 +1,12 @@
 package com.ardetrick.oryhydrareference.consent;
 
 import com.ardetrick.oryhydrareference.consent.ConsentResponse.Accepted;
+import com.ardetrick.oryhydrareference.consent.ConsentResponse.Denied;
 import com.ardetrick.oryhydrareference.consent.ConsentResponse.DisplayUI;
 import com.ardetrick.oryhydrareference.consent.ConsentResponse.Skip;
 import com.ardetrick.oryhydrareference.hydra.AcceptConsentRequest;
 import com.ardetrick.oryhydrareference.hydra.HydraAdminClient;
+import com.ardetrick.oryhydrareference.hydra.RejectConsentRequest;
 import lombok.AccessLevel;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +41,17 @@ public class ConsentService {
 
   public ConsentResponse processConsentForm(@NonNull final ConsentForm consentForm) {
     val consentChallenge = consentForm.consentChallenge();
+
+    if (consentForm.isDenied()) {
+      val rejectConsentRequest =
+          RejectConsentRequest.builder()
+              .consentChallenge(consentChallenge)
+              .error("access_denied")
+              .errorDescription("user denied access")
+              .build();
+      val rejectConsentResponse = hydraAdminClient.rejectConsentRequest(rejectConsentRequest);
+      return new Denied(rejectConsentResponse.getRedirectTo());
+    }
 
     val consentRequest = hydraAdminClient.getConsentRequest(consentChallenge);
 

--- a/reference-app/src/main/java/com/ardetrick/oryhydrareference/hydra/HydraAdminClient.java
+++ b/reference-app/src/main/java/com/ardetrick/oryhydrareference/hydra/HydraAdminClient.java
@@ -101,6 +101,20 @@ public class HydraAdminClient {
     }
   }
 
+  public OAuth2RedirectTo rejectConsentRequest(@NonNull RejectConsentRequest rejectConsentRequest) {
+    val rejectOAuth2Request = OryHydraRequestMapper.map(rejectConsentRequest);
+
+    try {
+      return oAuth2Api()
+          .rejectOAuth2ConsentRequest(rejectConsentRequest.consentChallenge(), rejectOAuth2Request);
+    } catch (ApiException e) {
+      switch (e.getCode()) {
+        case 404, 500 -> throw new RuntimeException("code: " + e.getCode(), e); // jsonError
+        default -> throw new RuntimeException("unhandled code: " + e.getCode(), e);
+      }
+    }
+  }
+
   @Data
   @org.springframework.context.annotation.Configuration
   @ConfigurationProperties("reference-app.hydra")

--- a/reference-app/src/main/java/com/ardetrick/oryhydrareference/hydra/OryHydraRequestMapper.java
+++ b/reference-app/src/main/java/com/ardetrick/oryhydrareference/hydra/OryHydraRequestMapper.java
@@ -3,6 +3,7 @@ package com.ardetrick.oryhydrareference.hydra;
 import lombok.NonNull;
 import sh.ory.hydra.model.AcceptOAuth2ConsentRequest;
 import sh.ory.hydra.model.AcceptOAuth2ConsentRequestSession;
+import sh.ory.hydra.model.RejectOAuth2Request;
 
 public class OryHydraRequestMapper {
 
@@ -16,6 +17,12 @@ public class OryHydraRequestMapper {
         .remember(acceptConsentRequest.remember())
         .rememberFor(DEFAULT_SESSION_EXPIRATION_IN_SECONDS)
         .session(getAcceptOAuth2ConsentRequestSession());
+  }
+
+  public static RejectOAuth2Request map(@NonNull final RejectConsentRequest rejectConsentRequest) {
+    return new RejectOAuth2Request()
+        .error(rejectConsentRequest.error())
+        .errorDescription(rejectConsentRequest.errorDescription());
   }
 
   private static AcceptOAuth2ConsentRequestSession getAcceptOAuth2ConsentRequestSession() {

--- a/reference-app/src/main/java/com/ardetrick/oryhydrareference/hydra/RejectConsentRequest.java
+++ b/reference-app/src/main/java/com/ardetrick/oryhydrareference/hydra/RejectConsentRequest.java
@@ -1,0 +1,8 @@
+package com.ardetrick.oryhydrareference.hydra;
+
+import lombok.Builder;
+import lombok.NonNull;
+
+@Builder
+public record RejectConsentRequest(
+    @NonNull String consentChallenge, @NonNull String error, String errorDescription) {}

--- a/reference-app/src/main/resources/templates/consent.ftlh
+++ b/reference-app/src/main/resources/templates/consent.ftlh
@@ -18,8 +18,8 @@
   <label for="remember">Remember me:</label>
   <input type="checkbox" id="remember" name="remember" checked /><br>
 
-  <input type="submit" id="accept" name="submit" value="Allow access" />
-  <input type="submit" id="reject" name="submit" value="Deny access" />
+  <input type="submit" id="accept" name="accept" value="Allow access" />
+  <input type="submit" id="reject" name="deny" value="Deny access" />
 </form>
 </body>
 </html>

--- a/reference-app/src/test/java/com/ardetrick/oryhydrareference/OryHydraReferenceApplicationFunctionalTests.java
+++ b/reference-app/src/test/java/com/ardetrick/oryhydrareference/OryHydraReferenceApplicationFunctionalTests.java
@@ -367,10 +367,13 @@ public class OryHydraReferenceApplicationFunctionalTests {
     assertThat(page.url()).contains("/client/callback?code=");
   }
 
-  private String getCodeFromCallbackCaptor() {
+  private String getCallbackQueryString() {
     verify(queryStringConsumer).accept(queryStringConsumerArgumentCaptor.capture());
-    val queryStringValue = queryStringConsumerArgumentCaptor.getValue();
-    return Arrays.stream(queryStringValue.split("&"))
+    return queryStringConsumerArgumentCaptor.getValue();
+  }
+
+  private String getCodeFromCallbackCaptor() {
+    return Arrays.stream(getCallbackQueryString().split("&"))
         .filter(queryStringParam -> queryStringParam.startsWith("code="))
         .findFirst()
         .map(queryStringParam -> queryStringParam.replace("code=", ""))
@@ -428,6 +431,39 @@ public class OryHydraReferenceApplicationFunctionalTests {
 
     // Consent screen is not skipped
     assertThat(page.url()).contains("/consent");
+  }
+
+  @Test
+  public void denyConsentRedirectsToClientWithAccessDeniedError() {
+    val screenshotPathProducer =
+        ScreenshotPathProducer.builder()
+            .testName("denyConsentRedirectsToClientWithAccessDeniedError")
+            .build();
+
+    val page = browser.newPage();
+
+    page.navigate(getUriToInitiateFlow().toString());
+    page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("initial-load"));
+
+    page.locator("input[name=loginEmail]").fill("foo@bar.com");
+    page.locator("input[name=loginPassword]").fill("password");
+
+    page.locator("input[name=submit]").click();
+
+    page.waitForLoadState();
+    page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("after-login-submit"));
+
+    page.locator("input[id=reject]").click();
+
+    page.waitForLoadState();
+    page.screenshot(screenshotPathProducer.screenshotOptionsForStepName("after-consent-deny"));
+
+    // The browser lands on the client's callback carrying a real OAuth error instead of a code.
+    assertThat(page.url()).contains("/client/callback?error=access_denied");
+
+    val queryString = getCallbackQueryString();
+    assertThat(queryString).contains("error=access_denied");
+    assertThat(queryString).doesNotContain("code=");
   }
 }
 


### PR DESCRIPTION
The consent screen has always rendered a Deny access button, but submitting it accepted the request anyway. Denying now calls Hydra's rejectOAuth2ConsentRequest with access_denied, and the app follows Hydra's real error redirect back to the client. The two submit buttons get distinct names so the controller knows which was clicked, the reject path mirrors the accept path's record/mapper shape, and a new Playwright test drives the full story — login, deny, and the browser landing on the client callback with error=access_denied and no code. Checks off "Allow rejecting on consent screen" from the README task list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)