### PR TITLE
docs(reference-app): collapse the walkthrough behind a disclosure

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,25 +244,32 @@ jwk [like this](https://jwt.io/#debugger-io?token=eyJhbGciOiJSUzI1NiIsImtpZCI6Im
 
 ## See it work
 
-A walk through the authorization code flow with OpenID Connect, from login to real
-tokens. Run `./gradlew bootTestRun` and open http://localhost:8080 to click through it
-yourself.
-
-Log in (the demo credentials are pre-filled):
-
-![login screen](docs/images/authorization-code-flow/1-login.png)
-
-Authorize the scopes the application is requesting:
+Log in, authorize the requested scopes, and the app exchanges the authorization code for
+real tokens from Hydra. Run `./gradlew bootTestRun` and open http://localhost:8080 to
+click through it yourself.
 
 ![consent screen](docs/images/authorization-code-flow/2-consent.png)
 
-Hydra redirects back with an authorization code, which the app exchanges for tokens:
+<details>
+<summary>See the full flow, step by step</summary>
+
+Log in — the demo credentials are pre-filled.
+
+![login screen](docs/images/authorization-code-flow/1-login.png)
+
+Authorize the scopes the application is requesting.
+
+![consent screen](docs/images/authorization-code-flow/2-consent.png)
+
+Hydra redirects back with an authorization code, which the app exchanges for tokens.
 
 ![callback screen](docs/images/authorization-code-flow/3-callback-page.png)
 
-The result is a real access token, ID token, and refresh token from Hydra:
+The result is a real access token, ID token, and refresh token from Hydra.
 
 ![token response](docs/images/authorization-code-flow/4-tokens.png)
+
+</details>
 
 ## Building against a different testcontainers-ory-hydra version
 


### PR DESCRIPTION
Reworks the "See it work" section into a hybrid: the consent screen shows inline as a single hero image, and the full four-step walkthrough (login → consent → callback → tokens) tucks behind a `<details>` the reader can expand to click through.

Keeps the landing README compact while still offering the full, reader-paced sequence — using the deterministic stills we already have, with no gif, video, or new tooling. Open the diff's rendered README to see the collapse behavior (it only shows on GitHub, not local preview).